### PR TITLE
[fix](rainbowkit): add connectors for wagmiconfig

### DIFF
--- a/pages/basePage.tsx
+++ b/pages/basePage.tsx
@@ -1,4 +1,5 @@
 import {
+  getDefaultWallets,
   RainbowKitProvider,
   ConnectButton,
   darkTheme,
@@ -29,7 +30,14 @@ const { chains, publicClient, webSocketPublicClient } = configureChains(
   [publicProvider()],
 );
 
+const { connectors } = getDefaultWallets({
+  appName: "RainbowKit App",
+  projectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ?? "",
+  chains,
+});
+
 const config = createConfig({
+  connectors,
   publicClient,
   webSocketPublicClient,
 });


### PR DESCRIPTION
## Types of changes

- **Bugfix**

## Description

The Rainbow wallet widget is unable to connect. When users click the button, it does not display the wallet type options.

## Checklist:

- [ ] Add connectors for wagmiconfig

## Additional context
<img width="708" alt="螢幕擷取畫面 2024-01-26 124128" src="https://github.com/all-weather-protocol/all-weather-frontend/assets/21350358/cc65e288-f13b-4d09-a6af-5af63a82ce21">
