### PR TITLE
[fix](wagmi): fixed connect wallet button refresh bug.

### DIFF
--- a/pages/basePage.tsx
+++ b/pages/basePage.tsx
@@ -37,6 +37,7 @@ const { connectors } = getDefaultWallets({
 });
 
 const config = createConfig({
+  autoConnect: true,
   connectors,
   publicClient,
   webSocketPublicClient,


### PR DESCRIPTION
## Types of changes

- **Bugfix**

## Description

The `Connect Wallet` button can only establish a connection once. After refreshing, the wallet disconnects.

## Checklist:

- [ ] set wagmi config `autoConnect: true,`