### PR TITLE
[fix](selectToken): Fix Bug Setting Value in Select Token

### DIFF
--- a/pages/views/ZapInButton.jsx
+++ b/pages/views/ZapInButton.jsx
@@ -447,7 +447,7 @@ const ZapInButton = () => {
         >
           {selectBefore((value) => {
             setChosenToken(value);
-          })}
+          }, "address")}
           <NumericInput
             placeholder={`Balance: ${
               chosenTokenBalance ? chosenTokenBalance.formatted : 0

--- a/pages/views/ZapOutButton.jsx
+++ b/pages/views/ZapOutButton.jsx
@@ -210,7 +210,7 @@ const ZapOutButton = () => {
         >
           {selectBefore((value) => {
             setChosenToken(value);
-          })}
+          }, "address")}
           <NumericInput
             placeholder={`Balance: ${userShares} SCLP`}
             value={inputValue}


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes

<!--Please remove the types that does not apply to this change-->

- **Bugfix**

## Description

<!--Describe what the change is**-->
When a user selects a token to "deposit" or "withdraw," the function returns an error.

## Checklist:

- [ ] Add `addressOrSymbol="address"` value to `selectBefore` function