### PR TITLE
Emergency Exit: sweep the whole chain, and fix the balance it always …

### DIFF
--- a/__tests__/intent/emergencyExit.test.js
+++ b/__tests__/intent/emergencyExit.test.js
@@ -1,8 +1,14 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ethers } from "ethers";
 import { encode } from "thirdweb";
 import { optimism } from "thirdweb/chains";
 import { getPortfolioHelper } from "../../utils/thirdwebSmartWallet.ts";
+import { fetchWalletTokens } from "../../utils/dustConversion";
+
+vi.mock("../../utils/dustConversion", async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchWalletTokens: vi.fn(),
+}));
 
 const OWNER = "0xc774806f9fF5f3d8aaBb6b70d0Ed509e42aFE6F0";
 const RECIPIENT = "0x1234567890123456789012345678901234567890";
@@ -10,6 +16,11 @@ const RECIPIENT = "0x1234567890123456789012345678901234567890";
 const TRANSFER_SELECTOR = "a9059cbb";
 // Gauge.withdraw(uint256)
 const WITHDRAW_SELECTOR = "2e1a7d4d";
+// Gauge.getReward(address)
+const GET_REWARD_SELECTOR = "c00007b0";
+// safeTransferFrom(address,address,uint256)
+const SAFE_TRANSFER_FROM_SELECTOR = "42842e0e";
+const VELO = "0x9560e827af36c94d2ac33a39bce1fe78631088db";
 const noop = () => {};
 
 const protocolsOn = (portfolioHelper, chain) =>
@@ -33,6 +44,33 @@ const stubBalances = (protocol, { staked, wallet }) => {
   );
 };
 
+// The claim leg reaches into protocol-specific code (RPC, third-party APIs);
+// tests that only assert on the principal pin it to "nothing to claim" so the
+// principal txns keep their index
+const stubNoRewards = (protocol) =>
+  vi.spyOn(protocol, "customClaim").mockResolvedValue([[], {}]);
+
+// Pins the reward read one level below customClaim, so the claim txn itself is
+// still built by the real protocol code
+const stubPendingRewards = (protocol, rewardsDict) =>
+  vi.spyOn(protocol, "pendingRewards").mockResolvedValue(rewardsDict);
+
+let getBalance;
+
+beforeEach(() => {
+  // Both the wallet scan and the native balance read are best-effort inputs.
+  // Neutral defaults keep the synthetic groups out of the way unless a test
+  // opts into them.
+  fetchWalletTokens.mockResolvedValue([]);
+  getBalance = vi
+    .spyOn(ethers.providers.BaseProvider.prototype, "getBalance")
+    .mockResolvedValue(ethers.constants.Zero);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("emergencyTransfer", () => {
   it("unstakes and transfers the full staked balance", async () => {
     const [protocol] = protocolsOn(
@@ -40,8 +78,9 @@ describe("emergencyTransfer", () => {
       "op",
     ).map((p) => p.interface);
     stubBalances(protocol, { staked: "1000000000000000000", wallet: "0" });
+    stubNoRewards(protocol);
 
-    const txns = await protocol.emergencyTransfer(OWNER, RECIPIENT, noop);
+    const { txns } = await protocol.emergencyTransfer(OWNER, RECIPIENT, noop);
 
     expect(txns).toHaveLength(2);
     expect(await encode(txns[0])).includes(WITHDRAW_SELECTOR);
@@ -59,11 +98,135 @@ describe("emergencyTransfer", () => {
       "op",
     ).map((p) => p.interface);
     stubBalances(protocol, { staked: "700", wallet: "300" });
+    stubNoRewards(protocol);
 
-    const txns = await protocol.emergencyTransfer(OWNER, RECIPIENT, noop);
+    const { txns } = await protocol.emergencyTransfer(OWNER, RECIPIENT, noop);
 
     expect(txns).toHaveLength(2);
     expect(await encode(txns[1])).includes(word("1000"));
+  });
+
+  // Camelot reports vesting xGRAIL as a pending reward, but only
+  // customRedeemVestingRewards can release it and xGRAIL cannot be transferred
+  // anyway. Promising it to a transfer would revert the batch it rides in.
+  it("leaves rewards that are still vesting out of the sweep", async () => {
+    const [protocol] = protocolsOn(
+      getPortfolioHelper("Velodrome Vault"),
+      "op",
+    ).map((p) => p.interface);
+    stubBalances(protocol, { staked: "1000", wallet: "0" });
+    stubPendingRewards(protocol, {
+      [ethers.utils.getAddress(VELO)]: {
+        symbol: "velo",
+        balance: ethers.BigNumber.from("700"),
+        decimals: 18,
+        vesting: true,
+        chain: "op",
+      },
+    });
+
+    const { rewardBalances } = await protocol.emergencyTransfer(
+      OWNER,
+      RECIPIENT,
+      noop,
+    );
+
+    expect(rewardBalances).toHaveLength(0);
+  });
+
+  // A claim that emits no transaction delivers nothing, so whatever balance it
+  // reported is still locked in the protocol
+  it("promises no reward transfer when the claim emits no transaction", async () => {
+    const [protocol] = protocolsOn(
+      getPortfolioHelper("Velodrome Vault"),
+      "op",
+    ).map((p) => p.interface);
+    stubBalances(protocol, { staked: "1000", wallet: "0" });
+    vi.spyOn(protocol, "customClaim").mockResolvedValue([
+      [],
+      {
+        [ethers.utils.getAddress(VELO)]: {
+          symbol: "velo",
+          balance: ethers.BigNumber.from("700"),
+          decimals: 18,
+        },
+      },
+    ]);
+
+    const { rewardBalances } = await protocol.emergencyTransfer(
+      OWNER,
+      RECIPIENT,
+      noop,
+    );
+
+    expect(rewardBalances).toHaveLength(0);
+  });
+
+  // Several protocols in one vault share a position manager, so an unscoped
+  // enumeration would make each of their groups try to move all of the wallet's
+  // NFTs and only the first could succeed
+  it("only lists NFT positions belonging to its own pool", async () => {
+    const [protocol] = protocolsOn(
+      getPortfolioHelper("Camelot Vault"),
+      "arbitrum",
+    ).map((p) => p.interface);
+    const { tickLower, tickUpper } = protocol.customParams.tickers;
+    const [token0, token1] = protocol.customParams.lpTokens;
+    const mine = {
+      tickLower,
+      tickUpper,
+      token0: token0[1],
+      token1: token1[1],
+    };
+    protocol.assetContractInstance = {
+      balanceOf: vi.fn().mockResolvedValue(ethers.BigNumber.from(3)),
+      tokenOfOwnerByIndex: vi
+        .fn()
+        .mockImplementation((_owner, idx) =>
+          Promise.resolve(ethers.BigNumber.from(100 + idx)),
+        ),
+      positions: vi.fn().mockImplementation((tokenId) =>
+        Promise.resolve(
+          Number(tokenId) === 101
+            ? {
+                tickLower: tickLower + 10,
+                tickUpper: tickUpper + 10,
+                token0: "0x000000000000000000000000000000000000dEaD",
+                token1: "0x000000000000000000000000000000000000bEEF",
+              }
+            : mine,
+        ),
+      ),
+    };
+
+    const tokenIds = await protocol._getAllNftIDs(OWNER);
+
+    expect(tokenIds.map(Number)).toEqual([100, 102]);
+  });
+
+  // Aave, Moonwell and PendlePT have no separate staking contract: _unstake
+  // emits no txn and sizes its amount off assetBalanceOf, so that amount already
+  // IS the wallet balance. Adding the wallet balance on top asks for twice what
+  // the user holds and reverts, which made the escape hatch useless for every
+  // one of those positions. The LP cases above cannot catch this because their
+  // staked balance is a genuinely separate number.
+  it("does not double-count the balance when there is no staking contract", async () => {
+    const [protocol] = protocolsOn(
+      getPortfolioHelper("Moonwell Stablecoin Vault"),
+      "base",
+    ).map((p) => p.interface);
+    vi.spyOn(protocol, "assetBalanceOf").mockResolvedValue(
+      ethers.BigNumber.from("1000"),
+    );
+    stubNoRewards(protocol);
+
+    const { txns } = await protocol.emergencyTransfer(OWNER, RECIPIENT, noop);
+
+    expect(txns).toHaveLength(1);
+    const transferData = await encode(txns[0]);
+    expect(transferData).includes(TRANSFER_SELECTOR);
+    expect(transferData).includes(word("1000"));
+    expect(transferData).not.includes(word("2000"));
   });
 
   it("skips the unstake txn when nothing is staked", async () => {
@@ -72,8 +235,9 @@ describe("emergencyTransfer", () => {
       "op",
     ).map((p) => p.interface);
     stubBalances(protocol, { staked: "0", wallet: "500" });
+    stubNoRewards(protocol);
 
-    const txns = await protocol.emergencyTransfer(OWNER, RECIPIENT, noop);
+    const { txns } = await protocol.emergencyTransfer(OWNER, RECIPIENT, noop);
 
     // withdraw(0) reverts on some gauges, so it must not be emitted
     expect(txns).toHaveLength(1);
@@ -88,10 +252,16 @@ describe("emergencyTransfer", () => {
       "op",
     ).map((p) => p.interface);
     stubBalances(protocol, { staked: "0", wallet: "0" });
+    stubNoRewards(protocol);
 
-    expect(await protocol.emergencyTransfer(OWNER, RECIPIENT, noop)).toEqual(
-      [],
+    const { txns, rewardBalances } = await protocol.emergencyTransfer(
+      OWNER,
+      RECIPIENT,
+      noop,
     );
+
+    expect(txns).toEqual([]);
+    expect(rewardBalances).toEqual([]);
   });
 
   it("never reads token prices", async () => {
@@ -100,6 +270,7 @@ describe("emergencyTransfer", () => {
       "op",
     ).map((p) => p.interface);
     stubBalances(protocol, { staked: "1000", wallet: "0" });
+    stubNoRewards(protocol);
     const usdBalanceOf = vi.spyOn(protocol, "usdBalanceOf");
     const assetUsdPrice = vi.spyOn(protocol, "assetUsdPrice");
 
@@ -107,6 +278,106 @@ describe("emergencyTransfer", () => {
 
     expect(usdBalanceOf).not.toHaveBeenCalled();
     expect(assetUsdPrice).not.toHaveBeenCalled();
+  });
+
+  it("claims first so the rewards are in the wallet before the principal moves", async () => {
+    const [protocol] = protocolsOn(
+      getPortfolioHelper("Velodrome Vault"),
+      "op",
+    ).map((p) => p.interface);
+    stubBalances(protocol, { staked: "1000", wallet: "0" });
+    stubPendingRewards(protocol, {
+      // checksummed on purpose: the caller de-duplicates on the address, so
+      // emergencyTransfer has to hand it back lowercased
+      [ethers.utils.getAddress(VELO)]: {
+        symbol: "velo",
+        balance: ethers.BigNumber.from("700"),
+        decimals: 18,
+        chain: "op",
+      },
+    });
+
+    const { txns, rewardBalances } = await protocol.emergencyTransfer(
+      OWNER,
+      RECIPIENT,
+      noop,
+    );
+
+    expect(txns).toHaveLength(3);
+    expect(await encode(txns[0])).includes(GET_REWARD_SELECTOR);
+    expect(await encode(txns[1])).includes(WITHDRAW_SELECTOR);
+    expect(await encode(txns[2])).includes(TRANSFER_SELECTOR);
+    expect(rewardBalances).toHaveLength(1);
+    expect(rewardBalances[0].address).toBe(VELO);
+    expect(rewardBalances[0].balance.toString()).toBe("700");
+  });
+
+  it("still moves the principal when the reward claim blows up", async () => {
+    const [protocol] = protocolsOn(
+      getPortfolioHelper("Velodrome Vault"),
+      "op",
+    ).map((p) => p.interface);
+    stubBalances(protocol, { staked: "1000", wallet: "0" });
+    vi.spyOn(protocol, "customClaim").mockRejectedValue(
+      new Error("reward api down"),
+    );
+
+    const { txns, rewardBalances } = await protocol.emergencyTransfer(
+      OWNER,
+      RECIPIENT,
+      noop,
+    );
+
+    // forfeiting rewards is survivable, being unable to withdraw principal is not
+    expect(txns).toHaveLength(2);
+    expect(await encode(txns[0])).includes(WITHDRAW_SELECTOR);
+    expect(await encode(txns[1])).includes(TRANSFER_SELECTOR);
+    expect(rewardBalances).toEqual([]);
+  });
+
+  it("moves every NFT position whole instead of reading a liquidity balance", async () => {
+    const [protocol] = protocolsOn(
+      getPortfolioHelper("Camelot Vault"),
+      "arbitrum",
+    ).map((p) => p.interface);
+    expect(protocol.assetIsNFT).toBe(true);
+    stubNoRewards(protocol);
+    vi.spyOn(protocol, "_getAllNftIDs").mockResolvedValue([
+      ethers.BigNumber.from("101"),
+      ethers.BigNumber.from("202"),
+    ]);
+    const assetBalanceOf = vi.spyOn(protocol, "assetBalanceOf");
+
+    const { txns } = await protocol.emergencyTransfer(OWNER, RECIPIENT, noop);
+
+    expect(txns).toHaveLength(2);
+    const encoded = await Promise.all(txns.map((txn) => encode(txn)));
+    encoded.forEach((data) => {
+      expect(data).includes(SAFE_TRANSFER_FROM_SELECTOR);
+      // an ERC20 transfer here would move the position manager's own balance
+      expect(data).not.toContain(TRANSFER_SELECTOR);
+    });
+    expect(encoded[0]).includes(word("101"));
+    expect(encoded[1]).includes(word("202"));
+    // assetBalanceOf reports pooled liquidity for an NFT, not a token count
+    expect(assetBalanceOf).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a wallet balance read that comes back undefined", async () => {
+    const [protocol] = protocolsOn(
+      getPortfolioHelper("Velodrome Vault"),
+      "op",
+    ).map((p) => p.interface);
+    stubBalances(protocol, { staked: "1000", wallet: "0" });
+    stubNoRewards(protocol);
+    // some assetBalanceOf implementations resolve to undefined once the
+    // underlying position is gone
+    vi.spyOn(protocol, "assetBalanceOf").mockResolvedValue(undefined);
+
+    const { txns } = await protocol.emergencyTransfer(OWNER, RECIPIENT, noop);
+
+    expect(txns).toHaveLength(2);
+    expect(await encode(txns[1])).includes(word("1000"));
   });
 });
 
@@ -120,6 +391,7 @@ describe("getEmergencyExitTxnsByProtocol", () => {
 
     protocols.forEach((protocol, i) => {
       stubBalances(protocol, { staked: "1000", wallet: "0" });
+      stubNoRewards(protocol);
       if (i === 0) {
         vi.spyOn(protocol, "stakeBalanceOf").mockRejectedValue(
           new Error("boom"),
@@ -145,9 +417,10 @@ describe("getEmergencyExitTxnsByProtocol", () => {
 
   it("never fetches the token price mapping table", async () => {
     const portfolioHelper = getPortfolioHelper("Velodrome Vault");
-    protocolsOn(portfolioHelper, "op").forEach((p) =>
-      stubBalances(p.interface, { staked: "1000", wallet: "0" }),
-    );
+    protocolsOn(portfolioHelper, "op").forEach((p) => {
+      stubBalances(p.interface, { staked: "1000", wallet: "0" });
+      stubNoRewards(p.interface);
+    });
     const getTokenPrices = vi.spyOn(
       portfolioHelper,
       "getTokenPricesMappingTable",
@@ -168,9 +441,10 @@ describe("getEmergencyExitTxnsByProtocol", () => {
     const protocols = protocolsOn(portfolioHelper, "op").map(
       (p) => p.interface,
     );
-    protocols.forEach((protocol) =>
-      stubBalances(protocol, { staked: "1000", wallet: "0" }),
-    );
+    protocols.forEach((protocol) => {
+      stubBalances(protocol, { staked: "1000", wallet: "0" });
+      stubNoRewards(protocol);
+    });
     const target = protocols[1].uniqueId();
 
     const groups = await portfolioHelper.getEmergencyExitTxnsByProtocol({
@@ -183,5 +457,139 @@ describe("getEmergencyExitTxnsByProtocol", () => {
 
     expect(groups).toHaveLength(1);
     expect(groups[0].uniqueId).toBe(target);
+  });
+
+  it("reports a failed wallet scan instead of quietly dropping the row", async () => {
+    const portfolioHelper = getPortfolioHelper("Velodrome Vault");
+    const protocols = protocolsOn(portfolioHelper, "op").map(
+      (p) => p.interface,
+    );
+    protocols.forEach((protocol) => {
+      stubBalances(protocol, { staked: "1000", wallet: "0" });
+      stubNoRewards(protocol);
+    });
+    fetchWalletTokens.mockRejectedValue(new Error("backend down"));
+
+    const groups = await portfolioHelper.getEmergencyExitTxnsByProtocol({
+      account: OWNER,
+      chainMetadata: optimism,
+      recipient: RECIPIENT,
+      updateProgress: noop,
+    });
+
+    // the positions still exit
+    protocols.forEach((protocol) => {
+      const group = groups.find((g) => g.uniqueId === protocol.uniqueId());
+      expect(group.buildError).toBeNull();
+      expect(group.txns).toHaveLength(2);
+    });
+    // and the user is told the loose tokens were never read, rather than the
+    // panel showing all-green while funds stayed behind
+    const walletGroup = groups.find((g) => g.uniqueId === "wallet-tokens");
+    expect(walletGroup.txns).toHaveLength(0);
+    expect(walletGroup.buildError).toContain("backend down");
+  });
+
+  it("keeps predicted reward amounts out of the confirmed wallet sweep", async () => {
+    const portfolioHelper = getPortfolioHelper("Velodrome Vault");
+    const [protocol] = protocolsOn(portfolioHelper, "op").map(
+      (p) => p.interface,
+    );
+    stubBalances(protocol, { staked: "1000", wallet: "0" });
+    stubPendingRewards(protocol, {
+      [ethers.utils.getAddress(VELO)]: {
+        symbol: "velo",
+        balance: ethers.BigNumber.from("700"),
+        decimals: 18,
+        chain: "op",
+      },
+    });
+    fetchWalletTokens.mockResolvedValue([
+      { id: VELO, raw_amount_hex_str: "0x12c" },
+    ]);
+
+    const groups = await portfolioHelper.getEmergencyExitTxnsByProtocol({
+      account: OWNER,
+      chainMetadata: optimism,
+      recipient: RECIPIENT,
+      updateProgress: noop,
+    });
+
+    expect(fetchWalletTokens).toHaveBeenCalledWith("op", OWNER);
+    // Split on purpose: 300 is what the wallet demonstrably holds, 700 is what a
+    // protocol predicts its claim will pay. Summing them would let a bad
+    // prediction revert the transfer of tokens the user definitely owns.
+    const walletGroup = groups.find((g) => g.uniqueId === "wallet-tokens");
+    expect(walletGroup.txns).toHaveLength(1);
+    const walletData = await encode(walletGroup.txns[0]);
+    expect(walletData).includes(TRANSFER_SELECTOR);
+    expect(walletData).includes(word("300"));
+
+    const rewardGroup = groups.find((g) => g.uniqueId === "claimed-rewards");
+    expect(rewardGroup.txns).toHaveLength(1);
+    const rewardData = await encode(rewardGroup.txns[0]);
+    expect(rewardData).includes(word("700"));
+  });
+
+  it("sends native last, and only from a wallet this app controls", async () => {
+    const portfolioHelper = getPortfolioHelper("Velodrome Vault");
+    protocolsOn(portfolioHelper, "op").forEach((p) => {
+      stubBalances(p.interface, { staked: "1000", wallet: "0" });
+      stubNoRewards(p.interface);
+    });
+    const nativeBalance = ethers.utils.parseEther("1");
+    getBalance.mockResolvedValue(nativeBalance);
+    fetchWalletTokens.mockResolvedValue([
+      { id: VELO, raw_amount_hex_str: "0x12c" },
+    ]);
+    const params = {
+      account: OWNER,
+      chainMetadata: optimism,
+      recipient: RECIPIENT,
+      updateProgress: noop,
+    };
+
+    const sponsored = await portfolioHelper.getEmergencyExitTxnsByProtocol({
+      ...params,
+      aaOn: true,
+    });
+    const eoa = await portfolioHelper.getEmergencyExitTxnsByProtocol({
+      ...params,
+      aaOn: false,
+    });
+
+    expect(sponsored.length).toBeGreaterThan(1);
+    expect(sponsored[sponsored.length - 1].uniqueId).toBe("native");
+    const sponsoredTxn = sponsored[sponsored.length - 1].txns[0];
+    expect(sponsoredTxn.to).toBe(RECIPIENT);
+    expect(sponsoredTxn.value).toBe(BigInt(nativeBalance.toString()));
+
+    // In EOA mode `account` is the user's own wallet holding whatever else they
+    // keep there; they asked to exit positions, not to be emptied out.
+    expect(eoa.every((group) => group.uniqueId !== "native")).toBe(true);
+    expect(eoa.every((group) => group.uniqueId !== "wallet-tokens")).toBe(true);
+    expect(eoa).toHaveLength(protocolsOn(portfolioHelper, "op").length);
+  });
+
+  it("rebuilds only the native group when the retry asks for it", async () => {
+    const portfolioHelper = getPortfolioHelper("Velodrome Vault");
+    const [protocol] = protocolsOn(portfolioHelper, "op").map(
+      (p) => p.interface,
+    );
+    const emergencyTransfer = vi.spyOn(protocol, "emergencyTransfer");
+    getBalance.mockResolvedValue(ethers.utils.parseEther("1"));
+
+    const groups = await portfolioHelper.getEmergencyExitTxnsByProtocol({
+      account: OWNER,
+      chainMetadata: optimism,
+      recipient: RECIPIENT,
+      updateProgress: noop,
+      uniqueIds: ["native"],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].uniqueId).toBe("native");
+    expect(emergencyTransfer).not.toHaveBeenCalled();
+    expect(fetchWalletTokens).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/intent/zapOutPartialFailure.test.js
+++ b/__tests__/intent/zapOutPartialFailure.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { optimism } from "thirdweb/chains";
+import { getPortfolioHelper } from "../../utils/thirdwebSmartWallet.ts";
+
+const OWNER = "0xc774806f9fF5f3d8aaBb6b70d0Ed509e42aFE6F0";
+const USDC_ON_OP = "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85";
+const noop = () => {};
+
+const protocolsOn = (portfolioHelper, chain) =>
+  Object.values(portfolioHelper.strategy).flatMap(
+    (category) => category[chain] || [],
+  );
+
+// Each protocol sizes its own withdrawal, so a stand-in txn is enough to prove
+// the surviving protocols still reach the batch
+const stubZapOut = (protocol) =>
+  vi
+    .spyOn(protocol, "zapOut")
+    .mockResolvedValue([{ zapOutOf: protocol.uniqueId() }]);
+
+const zapOutParams = (overrides) => ({
+  account: OWNER,
+  chainMetadata: optimism,
+  onlyThisChain: true,
+  zapOutPercentage: 1,
+  tokenOutSymbol: "usdc",
+  tokenOutAddress: USDC_ON_OP,
+  tokenOutDecimals: 6,
+  slippage: 0.5,
+  setTotalTradingLoss: noop,
+  setTradingLoss: noop,
+  setPlatformFee: noop,
+  ...overrides,
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("zapOut with an unreachable protocol", () => {
+  it("drops the failing protocol and names it instead of losing the batch", async () => {
+    const portfolioHelper = getPortfolioHelper("Stable+ Vault");
+    vi.spyOn(portfolioHelper, "getTokenPricesMappingTable").mockResolvedValue(
+      {},
+    );
+    const [broken, ...healthy] = protocolsOn(portfolioHelper, "op").map(
+      (p) => p.interface,
+    );
+    expect(healthy.length).toBeGreaterThan(0);
+
+    vi.spyOn(broken, "usdBalanceOf").mockRejectedValue(
+      new Error("price feed down"),
+    );
+    const brokenZapOut = stubZapOut(broken);
+    healthy.forEach((protocol) => {
+      vi.spyOn(protocol, "usdBalanceOf").mockResolvedValue(100);
+      stubZapOut(protocol);
+    });
+    const onProtocolsSkipped = vi.fn();
+
+    const txns = await portfolioHelper.portfolioAction(
+      "zapOut",
+      zapOutParams({ onProtocolsSkipped }),
+    );
+
+    expect(txns).toEqual(
+      healthy.map((protocol) => ({ zapOutOf: protocol.uniqueId() })),
+    );
+    expect(brokenZapOut).not.toHaveBeenCalled();
+    expect(onProtocolsSkipped).toHaveBeenCalledTimes(1);
+    const skipped = onProtocolsSkipped.mock.calls[0][0];
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].uniqueId).toBe(broken.uniqueId());
+    expect(skipped[0].error).toContain("price feed down");
+  });
+
+  it("reports nothing when every protocol produces txns", async () => {
+    const portfolioHelper = getPortfolioHelper("Stable+ Vault");
+    vi.spyOn(portfolioHelper, "getTokenPricesMappingTable").mockResolvedValue(
+      {},
+    );
+    const protocols = protocolsOn(portfolioHelper, "op").map(
+      (p) => p.interface,
+    );
+    protocols.forEach((protocol) => {
+      vi.spyOn(protocol, "usdBalanceOf").mockResolvedValue(100);
+      stubZapOut(protocol);
+    });
+    const onProtocolsSkipped = vi.fn();
+
+    const txns = await portfolioHelper.portfolioAction(
+      "zapOut",
+      zapOutParams({ onProtocolsSkipped }),
+    );
+
+    expect(txns).toHaveLength(protocols.length);
+    expect(onProtocolsSkipped).not.toHaveBeenCalled();
+  });
+});

--- a/classes/BasePortfolio.jsx
+++ b/classes/BasePortfolio.jsx
@@ -1,9 +1,9 @@
 import { tokensAndCoinmarketcapIdsFromDropdownOptions } from "../utils/contractInteractions";
 import assert from "assert";
 import { oneInchAddress } from "../utils/oneInch";
-import { approve } from "../utils/general";
+import { approve, PROVIDER } from "../utils/general";
 import { ethers } from "ethers";
-import { getContract, prepareContractCall } from "thirdweb";
+import { getContract, prepareContractCall, prepareTransaction } from "thirdweb";
 import THIRDWEB_CLIENT from "../utils/thirdweb";
 import ERC20_ABI from "../lib/contracts/ERC20.json" assert { type: "json" };
 import WETH from "../lib/contracts/Weth.json" assert { type: "json" };
@@ -18,8 +18,32 @@ import { getProtocolObjByUniqueId } from "../utils/portfolioCalculation";
 import flowChartEventEmitter from "../utils/FlowChartEventEmitter";
 import logger from "../utils/logger";
 import { normalizeChainName } from "../utils/chainHelper";
+import { fetchWalletTokens } from "../utils/dustConversion";
 const PROTOCOL_TREASURY_ADDRESS = "0x2eCBC6f229feD06044CDb0dD772437a30190CD50";
 const REWARD_SLIPPAGE = 0.8;
+// Keyed on both thirdweb's display name and the normalized form, because the
+// emergency exit can be handed either. Unknown chains throw rather than build a
+// URL the backend will reject, so the panel reports the gap instead of hiding it.
+const DEBANK_CHAIN_CODE = {
+  ethereum: "eth",
+  eth: "eth",
+  arbitrum: "arb",
+  "arbitrum one": "arb",
+  base: "base",
+  optimism: "op",
+  op: "op",
+  "op mainnet": "op",
+  bsc: "bsc",
+};
+const debankChainCode = (chainMetadata) => {
+  const raw = String(chainMetadata?.name || "").toLowerCase();
+  const code =
+    DEBANK_CHAIN_CODE[raw] || DEBANK_CHAIN_CODE[normalizeChainName(raw)];
+  if (!code) {
+    throw new Error(`no Debank chain code for "${chainMetadata?.name}"`);
+  }
+  return code;
+};
 
 // Add cache for the entire mapping table
 const GLOBAL_MAPPING_CACHE = {
@@ -486,16 +510,26 @@ export class BasePortfolio {
   // Escape hatch behind the Emergency Exit panel. Deliberately bypasses
   // portfolioAction() — which always awaits getTokenPricesMappingTable() — and
   // _processProtocolActions(), whose Promise.all drops the entire batch as soon
-  // as one protocol throws. Returns one group per protocol so the caller can
-  // submit and fail each independently.
+  // as one protocol throws. Every group is submittable on its own so one dead
+  // protocol cannot strand the rest.
+  //
+  // The reward claim inside emergencyTransfer is allowed to fail silently
+  // (protocol-specific, sometimes third-party); losing it only forfeits rewards.
+  // The wallet scan is not: a missing scan means loose tokens stayed behind, and
+  // an exit that reports success while leaving funds is worse than one that says
+  // it could not look.
   async getEmergencyExitTxnsByProtocol({
     account,
     chainMetadata,
     recipient,
     updateProgress,
     uniqueIds = null,
+    aaOn = true,
   }) {
     const currentChain = normalizeChainName(chainMetadata.name);
+    // a retry names the groups it wants; the synthetic groups below match no
+    // protocol, so they have to be recognised by name
+    const wanted = (uniqueId) => !uniqueIds || uniqueIds.includes(uniqueId);
     const targets = [];
     for (const protocolsInThisCategory of Object.values(this.strategy)) {
       for (const [chain, protocols] of Object.entries(
@@ -505,9 +539,7 @@ export class BasePortfolio {
         for (const protocol of protocols) {
           // weight === 0 protocols are precisely the ones needing rescue:
           // deprecated chains get zeroed out while still holding user funds
-          if (uniqueIds && !uniqueIds.includes(protocol.interface.uniqueId())) {
-            continue;
-          }
+          if (!wanted(protocol.interface.uniqueId())) continue;
           targets.push(protocol);
         }
       }
@@ -523,18 +555,166 @@ export class BasePortfolio {
       ),
     );
 
-    return targets
-      .map((protocol, i) => ({
+    // lowercase token address -> amount. Rewards are kept apart from the wallet
+    // snapshot because their amounts come from different places: a Debank balance
+    // is what the wallet demonstrably holds, while a reward amount is what a
+    // protocol predicts its claim will deliver (Equilibria multiplies out a
+    // factor, Camelot reads an API). Mixing them would let one bad prediction
+    // revert the transfer of tokens the user definitely owns.
+    const walletTotals = {};
+    const rewardTotals = {};
+    const addTo = (bucket, address, balance) => {
+      const key = address.toLowerCase();
+      bucket[key] = (bucket[key] || ethers.constants.Zero).add(balance);
+    };
+    // A protocol group already sweeps its own asset token out of the wallet, so
+    // the wallet scan must not build a second transfer for the same address —
+    // but only where that group actually produced the transfer. A protocol that
+    // failed to build moves nothing, and its receipt token has to stay eligible.
+    const sweptByProtocol = new Set();
+
+    const groups = [];
+    targets.forEach((protocol, i) => {
+      const result = settled[i];
+      const txns =
+        result.status === "fulfilled" ? result.value?.txns || [] : [];
+      const buildError =
+        result.status === "rejected"
+          ? result.reason?.message || String(result.reason)
+          : null;
+      if (txns.length === 0 && !buildError) return;
+      groups.push({
         uniqueId: protocol.interface.uniqueId(),
         label: protocol.interface.toString(),
         chain: currentChain,
-        txns: settled[i].status === "fulfilled" ? settled[i].value : [],
-        buildError:
-          settled[i].status === "rejected"
-            ? settled[i].reason?.message || String(settled[i].reason)
+        txns,
+        buildError,
+      });
+      if (buildError) return;
+      const assetAddress = protocol.interface.assetContract?.address;
+      if (assetAddress && !protocol.interface.assetIsNFT) {
+        sweptByProtocol.add(assetAddress.toLowerCase());
+      }
+      // rewards only ever reach the wallet if this group's claim goes out
+      for (const { address, balance } of result.value?.rewardBalances || []) {
+        addTo(rewardTotals, address, balance);
+      }
+    });
+
+    const erc20TransferTxn = (address, amount) =>
+      prepareContractCall({
+        contract: getContract({
+          client: THIRDWEB_CLIENT,
+          address,
+          chain: chainMetadata,
+          abi: ERC20_ABI,
+        }),
+        method: "function transfer(address to, uint256 amount)",
+        params: [recipient, amount],
+      });
+    const bucketToTxns = (bucket) =>
+      Object.entries(bucket)
+        .filter(([, amount]) => amount.gt(0))
+        .map(([address, amount]) => erc20TransferTxn(address, amount));
+
+    // In EOA mode `account` is the user's own wallet, holding whatever else they
+    // keep there. They asked to exit their positions, not to have their wallet
+    // emptied, so the indiscriminate sweeps only run against an AA wallet, which
+    // holds nothing but what this app put there.
+    if (aaOn && wanted("wallet-tokens")) {
+      let scanError = null;
+      try {
+        const walletTokens = await fetchWalletTokens(
+          debankChainCode(chainMetadata),
+          account,
+        );
+        for (const token of walletTokens) {
+          // the native token is listed under a chain name rather than an
+          // address, and needs a value transfer instead of an ERC20 one
+          if (!ethers.utils.isAddress(token.id)) continue;
+          if (sweptByProtocol.has(token.id.toLowerCase())) continue;
+          try {
+            addTo(
+              walletTotals,
+              token.id,
+              ethers.BigNumber.from(token.raw_amount_hex_str),
+            );
+          } catch (error) {
+            // one unreadable amount must not drop the tokens listed after it
+            logger.warn(
+              `Emergency Exit: skipping ${
+                token.optimized_symbol || token.id
+              }, unreadable balance`,
+              error,
+            );
+          }
+        }
+      } catch (error) {
+        scanError = error;
+        logger.warn("Emergency Exit: wallet token scan unavailable", error);
+      }
+      const walletTxns = bucketToTxns(walletTotals);
+      if (walletTxns.length > 0 || scanError) {
+        groups.push({
+          uniqueId: "wallet-tokens",
+          label: scanError
+            ? "Loose wallet tokens"
+            : `Loose wallet tokens (${walletTxns.length})`,
+          chain: currentChain,
+          txns: scanError ? [] : walletTxns,
+          // surfaced as a failed row rather than swallowed, so the panel can
+          // never imply the wallet was emptied when it was never read
+          buildError: scanError
+            ? `Could not list wallet tokens (${
+                scanError.message || scanError
+              }). Loose tokens were left behind — retry this row once the API recovers.`
             : null,
-      }))
-      .filter((group) => group.txns.length > 0 || group.buildError);
+        });
+      }
+    }
+
+    if (aaOn && wanted("claimed-rewards")) {
+      const rewardTxns = bucketToTxns(rewardTotals);
+      if (rewardTxns.length > 0) {
+        groups.push({
+          uniqueId: "claimed-rewards",
+          label: `Claimed rewards (${rewardTxns.length})`,
+          chain: currentChain,
+          txns: rewardTxns,
+          buildError: null,
+        });
+      }
+    }
+
+    // Native goes last: by then every earlier batch has already paid its gas.
+    if (aaOn && wanted("native")) {
+      try {
+        const nativeBalance = await PROVIDER(currentChain).getBalance(account);
+        if (nativeBalance.gt(0)) {
+          groups.push({
+            uniqueId: "native",
+            label: "Native ETH",
+            chain: currentChain,
+            txns: [
+              prepareTransaction({
+                to: recipient,
+                chain: chainMetadata,
+                client: THIRDWEB_CLIENT,
+                value: BigInt(nativeBalance.toString()),
+              }),
+            ],
+            buildError: null,
+          });
+        }
+      } catch (error) {
+        logger.warn(
+          "Emergency Exit: could not read native balance, skipping it",
+          error,
+        );
+      }
+    }
+
+    return groups;
   }
 
   _calculateDerivative(currentChain, onlyThisChain) {
@@ -705,6 +885,9 @@ export class BasePortfolio {
 
     const processProtocolTxns = async (currentChain) => {
       const protocolPromises = [];
+      // parallel to protocolPromises: allSettled results carry no identity, so
+      // a skipped protocol has to be named from its index
+      const protocolUniqueIds = [];
 
       const derivative = this._calculateDerivative(
         currentChain,
@@ -736,7 +919,44 @@ export class BasePortfolio {
           });
 
           protocolPromises.push(...chainProtocolPromises);
+          protocolUniqueIds.push(
+            ...protocols.map((protocol) => protocol.interface?.uniqueId?.()),
+          );
         }
+      }
+      // zapOut is the only action that can survive a partial batch: each
+      // protocol sizes its withdrawal from its own balance and nothing is
+      // carried between them, so dropping one cannot skew the others' amounts.
+      if (actionName === "zapOut") {
+        const settled = await Promise.allSettled(protocolPromises);
+        const skipped = settled.flatMap((result, i) =>
+          result.status === "rejected"
+            ? [
+                {
+                  uniqueId: protocolUniqueIds[i],
+                  error: result.reason?.message || String(result.reason),
+                },
+              ]
+            : [],
+        );
+        if (skipped.length > 0) {
+          actionParams.onProtocolsSkipped?.(skipped);
+        }
+        const txns = settled
+          .flatMap((result) =>
+            result.status === "fulfilled" ? result.value : [],
+          )
+          .filter(Boolean);
+        // Tolerating failures must not also hide them: with nothing left to send
+        // the generic "no txns" downstream would bury why every protocol failed.
+        if (txns.length === 0 && skipped.length > 0) {
+          throw new Error(
+            `Withdrawal failed for every position: ${skipped
+              .map((entry) => `${entry.uniqueId || "unknown"} (${entry.error})`)
+              .join("; ")}`,
+          );
+        }
+        return txns;
       }
       // Wait for all protocol transactions to complete
       const results = await Promise.all(protocolPromises);

--- a/classes/BaseProtocol.js
+++ b/classes/BaseProtocol.js
@@ -25,6 +25,9 @@ export default class BaseProtocol extends BaseUniswap {
     this.assetContract = "placeholder";
     this.protocolContract = "placeholder";
     this.stakeFarmContract = "placeholder";
+    // subclasses whose assetContract is an ERC721 position manager flip this,
+    // because balance/transfer semantics differ from a fungible position
+    this.assetIsNFT = false;
 
     this.chain = chain;
     this.chainId = chaindId;
@@ -463,51 +466,115 @@ export default class BaseProtocol extends BaseUniswap {
     return finalTxns;
   }
 
-  // Escape hatch: unstake everything and hand the raw asset token to the user.
-  // Unlike transfer(), this reads nothing but on-chain BigNumbers — no token
-  // prices, no slippage, no swaps — so a broken price feed (e.g. OP's depegged
-  // sUSD) cannot block the exit. Only valid where assetContract is a plain
-  // ERC20; NFT-based positions will fail here and get skipped by the caller.
+  // Escape hatch: hand the whole position back to the user untouched.
+  // The principal path reads nothing but on-chain BigNumbers — no token prices,
+  // no slippage, no swaps — so a broken price feed (e.g. OP's depegged sUSD)
+  // cannot block the exit. Claiming rewards is the one part that reaches into
+  // protocol-specific code with third-party dependencies (Camelot's API,
+  // Equilibria's reward assumptions), so it is best-effort only: forfeiting
+  // rewards is survivable, being unable to withdraw principal is not.
   async emergencyTransfer(owner, recipient, updateProgress) {
-    let unstakeTxns;
-    let unstakedAmount;
-    if (this.mode === "single") {
-      [unstakeTxns, unstakedAmount] = await this._unstake(
+    let claimTxns = [];
+    let rewardBalances = [];
+    try {
+      // an empty price table only NaNs out usdDenominatedValue, which nothing
+      // downstream of an emergency exit reads
+      const [txns, rewardsDict] = await this.customClaim(
         owner,
-        1,
+        {},
         updateProgress,
       );
-    } else if (this.mode === "LP") {
-      [unstakeTxns, unstakedAmount] = await this._unstakeLP(
-        owner,
-        1,
-        updateProgress,
+      claimTxns = txns || [];
+      // A claim that emits no transaction delivers nothing, so any balance it
+      // reported is still locked in the protocol and must not be promised to a
+      // transfer. Same for escrowed entries: Camelot reports vesting xGRAIL as
+      // a pending reward, but only customRedeemVestingRewards can release it —
+      // and xGRAIL cannot be transferred even once released.
+      rewardBalances =
+        claimTxns.length === 0
+          ? []
+          : Object.entries(rewardsDict || {}).flatMap(([address, metadata]) => {
+              if (metadata?.balance === undefined || metadata?.vesting) {
+                return [];
+              }
+              const balance = ethers.BigNumber.from(metadata.balance);
+              return balance.isZero()
+                ? []
+                : [{ address: address.toLowerCase(), balance }];
+            });
+    } catch (error) {
+      logger.warn(
+        `emergencyTransfer: giving up on rewards for ${this.uniqueId()}, continuing with principal`,
+        error,
+      );
+    }
+
+    let principalTxns = [];
+    if (this.assetIsNFT) {
+      // NFT positions are never staked (_stakeLP is a no-op for them), so there
+      // is nothing to unstake, and assetBalanceOf would report liquidity rather
+      // than a token count
+      const tokenIds = await this._getAllNftIDs(owner);
+      principalTxns = (tokenIds || []).map((tokenId) =>
+        prepareContractCall({
+          contract: this.assetContract,
+          // the 4-arg overload lives in the same ABI, so the full signature is
+          // needed to resolve which one this is
+          method:
+            "function safeTransferFrom(address from, address to, uint256 tokenId)",
+          params: [owner, recipient, tokenId],
+        }),
       );
     } else {
-      throw new Error("Invalid mode for emergencyTransfer");
+      let unstakeTxns;
+      let unstakedAmount;
+      if (this.mode === "single") {
+        [unstakeTxns, unstakedAmount] = await this._unstake(
+          owner,
+          1,
+          updateProgress,
+        );
+      } else if (this.mode === "LP") {
+        [unstakeTxns, unstakedAmount] = await this._unstakeLP(
+          owner,
+          1,
+          updateProgress,
+        );
+      } else {
+        throw new Error("Invalid mode for emergencyTransfer");
+      }
+
+      const unstakedAmountBN = ethers.BigNumber.from(unstakedAmount || 0);
+      // Protocols with no separate staking contract (Aave, Moonwell, PendlePT)
+      // return no unstake txn and size the amount off assetBalanceOf itself, so
+      // it already *is* the wallet balance — adding it again asks for twice what
+      // the user holds and reverts. Only where an unstake txn moves tokens into
+      // the wallet are the two amounts distinct; sweeping the pre-existing
+      // balance there costs no extra txn and heals a half-finished exit
+      // (unstake landed, transfer didn't) on the retry.
+      const total =
+        unstakeTxns.length === 0
+          ? unstakedAmountBN
+          : unstakedAmountBN.add((await this.assetBalanceOf(owner)) || 0);
+      if (!total.isZero()) {
+        const transferTxn = prepareContractCall({
+          contract: this.assetContract,
+          method: "transfer",
+          params: [recipient, total],
+        });
+        // withdraw(0) reverts on some gauges
+        principalTxns = unstakedAmountBN.isZero()
+          ? [transferTxn]
+          : [...unstakeTxns, transferTxn];
+      }
     }
 
-    // _unstakeLP returns undefined here when an NFT position was already burned
-    const unstakedAmountBN = ethers.BigNumber.from(unstakedAmount || 0);
-    // Sweeping the wallet balance too costs no extra txn and makes a
-    // half-finished exit (unstake landed, transfer didn't) heal on the retry
-    const walletBalance = await this.assetBalanceOf(owner);
-    const total = unstakedAmountBN.add(walletBalance);
-    if (total.isZero()) {
-      return [];
+    // claims go first so the rewards land in the wallet within the same batch
+    const finalTxns = [...claimTxns, ...principalTxns];
+    if (finalTxns.length > 0) {
+      this.checkTxnsToDataNotUndefined(finalTxns, "emergencyTransfer");
     }
-
-    const transferTxn = prepareContractCall({
-      contract: this.assetContract,
-      method: "transfer",
-      params: [recipient, total],
-    });
-    // withdraw(0) reverts on some gauges
-    const finalTxns = unstakedAmountBN.isZero()
-      ? [transferTxn]
-      : [...unstakeTxns, transferTxn];
-    this.checkTxnsToDataNotUndefined(finalTxns, "emergencyTransfer");
-    return finalTxns;
+    return { txns: finalTxns, rewardBalances };
   }
 
   async stake(protocolAssetDustInWallet, updateProgress) {

--- a/classes/Velodrome/BaseVelodromeV3.js
+++ b/classes/Velodrome/BaseVelodromeV3.js
@@ -16,6 +16,7 @@ import NonfungiblePositionManager from "../../lib/contracts/AerodromeV3/Nonfungi
 export class BaseVelodromeV3 extends BaseProtocol {
   constructor(chain, chainId, symbolList, mode, customParams) {
     super(chain, chainId, symbolList, mode, customParams);
+    this.assetIsNFT = true;
     this.initializeProtocolDetails();
     this.initializeContracts();
     this._checkIfParamsAreSet();
@@ -492,6 +493,38 @@ export class BaseVelodromeV3 extends BaseProtocol {
       }
     }
     return 0;
+  }
+  // Every position this wallet holds in *this* pool, unlike _getNftID which
+  // stops at the first. Scoped to the pool on purpose: several protocols in a
+  // vault share one position manager, so an unscoped list would make each of
+  // their emergency-exit groups try to move all of the wallet's NFTs and only
+  // the first would succeed.
+  async _getAllNftIDs(owner) {
+    const { tickLower, tickUpper } = this.customParams.tickers;
+    const [token0Metadata, token1Metadata] = this.customParams.lpTokens;
+    const balances = await this.assetContractInstance.balanceOf(owner);
+    const tokenIds = [];
+    for (let idx = 0; idx < Math.min(Number(balances), 50); idx++) {
+      // A single unreadable position must not strand the remaining ones
+      try {
+        const token_id = await this.assetContractInstance.tokenOfOwnerByIndex(
+          owner,
+          idx,
+        );
+        const position = await this.assetContractInstance.positions(token_id);
+        if (
+          position.tickLower === tickLower &&
+          position.tickUpper === tickUpper &&
+          position.token0.toLowerCase() === token0Metadata[1].toLowerCase() &&
+          position.token1.toLowerCase() === token1Metadata[1].toLowerCase()
+        ) {
+          tokenIds.push(token_id);
+        }
+      } catch (error) {
+        continue;
+      }
+    }
+    return tokenIds;
   }
   async _checkIfNFTExists(token_id) {
     try {

--- a/classes/camelot/BaseCamelot.js
+++ b/classes/camelot/BaseCamelot.js
@@ -21,6 +21,7 @@ export class BaseCamelot extends BaseProtocol {
     this.protocolVersion = "v3";
     this.assetDecimals = 18;
     this.token_id;
+    this.assetIsNFT = true;
 
     this.assetContract = getContract({
       client: THIRDWEB_CLIENT,
@@ -496,6 +497,38 @@ export class BaseCamelot extends BaseProtocol {
       }
     }
     return 0;
+  }
+  // Every position this wallet holds in *this* pool, unlike _getNftID which
+  // stops at the first. Scoped to the pool on purpose: several protocols in a
+  // vault share one position manager, so an unscoped list would make each of
+  // their emergency-exit groups try to move all of the wallet's NFTs and only
+  // the first would succeed.
+  async _getAllNftIDs(owner) {
+    const { tickLower, tickUpper } = this.customParams.tickers;
+    const [token0Metadata, token1Metadata] = this.customParams.lpTokens;
+    const balances = await this.assetContractInstance.balanceOf(owner);
+    const tokenIds = [];
+    for (let idx = 0; idx < Math.min(Number(balances), 50); idx++) {
+      // A single unreadable position must not strand the remaining ones
+      try {
+        const token_id = await this.assetContractInstance.tokenOfOwnerByIndex(
+          owner,
+          idx,
+        );
+        const position = await this.assetContractInstance.positions(token_id);
+        if (
+          position.tickLower === tickLower &&
+          position.tickUpper === tickUpper &&
+          position.token0.toLowerCase() === token0Metadata[1].toLowerCase() &&
+          position.token1.toLowerCase() === token1Metadata[1].toLowerCase()
+        ) {
+          tokenIds.push(token_id);
+        }
+      } catch (error) {
+        continue;
+      }
+    }
+    return tokenIds;
   }
   async _checkIfNFTExists(token_id) {
     try {

--- a/classes/main.js
+++ b/classes/main.js
@@ -24,6 +24,7 @@ export const generateIntentTxns = async ({
   usdBalance,
   tokenPricesMappingTable,
   handleStatusUpdate,
+  onProtocolsSkipped,
 }) => {
   let txns;
   if (actionName === "zapIn") {
@@ -60,6 +61,7 @@ export const generateIntentTxns = async ({
       onlyThisChain,
       protocolAssetDustInWallet,
       protocolAssetDustInWalletLoading,
+      onProtocolsSkipped,
     });
   } else if (actionName === "claimAndSwap") {
     txns = await portfolioHelper.portfolioAction(actionName, {

--- a/components/tabs/EmergencyExitPanel.jsx
+++ b/components/tabs/EmergencyExitPanel.jsx
@@ -108,24 +108,37 @@ export default function EmergencyExitPanel({
                 description={
                   <div className="text-sm">
                     <p className="mb-1">
-                      This unstakes every position on {chainName} and sends the
-                      raw LP / receipt tokens to the address below.{" "}
+                      This hands everything this app holds for you on{" "}
+                      {chainName} to the address below: every position unstaked
+                      and sent as raw LP / receipt tokens, NFT positions moved
+                      whole, pending rewards claimed, plus any loose ERC20 and
+                      ETH left in your smart wallet.{" "}
                       <span className="font-bold">
                         No swaps, no slippage, no price lookups
                       </span>{" "}
                       — so it still works when a token has depegged and breaks
-                      the normal withdraw path.
+                      the normal withdraw path. Native ETH goes last, so there
+                      is gas left for everything ahead of it.
                     </p>
                     <p className="mb-1">
-                      Each position is sent as its own transaction. If one
-                      fails, the rest still go through and you can retry just
-                      that one.
+                      Each line in the results below is its own transaction. If
+                      one fails, the rest still go through and you can retry
+                      just that one.
+                    </p>
+                    <p className="mb-1">
+                      The list of loose wallet tokens comes from our backend. If
+                      that API is down you will see a failed{" "}
+                      <span className="font-mono">Loose wallet tokens</span> row
+                      — your positions still exit, but the loose tokens stay put
+                      until you retry that row.
                     </p>
                     <p className="mb-0">
                       You will receive{" "}
-                      <span className="font-bold">LP tokens</span>, not
-                      stablecoins. To cash out you then remove liquidity
-                      yourself on the protocol&apos;s own site (e.g.
+                      <span className="font-bold">
+                        raw LP / receipt tokens, plain ERC20s and ETH
+                      </span>
+                      , not stablecoins. Anything held as liquidity you then
+                      unwind yourself on the protocol&apos;s own site (e.g.
                       velodrome.finance for Velodrome pools).
                     </p>
                   </div>
@@ -218,9 +231,23 @@ export default function EmergencyExitPanel({
               )}
 
               <p className="text-xs text-gray-400">
-                Pending reward tokens stay credited to this wallet and can still
-                be collected from the Claim tab afterwards. Positions held as
-                NFTs cannot be moved this way and will show as failed.
+                Pending rewards are claimed first and then sent as a separate{" "}
+                <span className="font-mono">Claimed rewards</span> row, so a
+                protocol that over-reports what its claim will pay out can only
+                cost you that row. Amounts are fixed while the transactions are
+                built, so a little dust can stay behind, and rewards still
+                locked in vesting are left alone because nothing can move them
+                yet. Retrying a single position re-claims its rewards but does
+                not re-send them — run the full exit again to sweep those up.
+              </p>
+              <p className="text-xs text-gray-400">
+                NFT positions (Camelot, Velodrome V3) are moved whole, except
+                any NFT you staked into a gauge or nitro pool outside zapPilot:
+                only what the position manager reports for this wallet is
+                visible here. Loose wallet tokens and ETH are only swept from a
+                smart wallet — in <span className="font-mono">?mode=eoa</span>{" "}
+                the exit touches your protocol positions and nothing else, so
+                the rest of your wallet is left alone.
               </p>
             </div>
           ),

--- a/pages/indexes/indexOverviews.jsx
+++ b/pages/indexes/indexOverviews.jsx
@@ -147,6 +147,15 @@ const cleanupActionParams = (params) => {
 
   return cleanedParams;
 };
+// uniqueId is chain/protocol/version/symbols/type, which is too long for a
+// notification line — only the protocol and its symbols mean anything to a user
+const shortenProtocolId = (uniqueId) => {
+  // a protocol whose interface never resolved reports no id at all, and a
+  // notification that throws is worse than one naming an unknown position
+  if (typeof uniqueId !== "string") return "unknown position";
+  const [, protocolName, , symbols] = uniqueId.split("/");
+  return protocolName ? `${protocolName} ${symbols || ""}`.trim() : uniqueId;
+};
 export default function IndexOverviews() {
   const router = useRouter();
   const { portfolioName } = router.query;
@@ -216,6 +225,9 @@ export default function IndexOverviews() {
   const [emergencyExitStatus, setEmergencyExitStatus] = useState({});
 
   const preservedAmountRef = useRef(null);
+  // Read back inside the same handleAAWalletAction call that filled it, so state
+  // would only cost a render and arrive too late for the success notification
+  const skippedProtocolsRef = useRef([]);
 
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const { aaOn } = useWalletMode();
@@ -273,6 +285,7 @@ export default function IndexOverviews() {
       setTotalTradingLoss(0);
       setTradingLoss(0);
       setErrorMsg("");
+      skippedProtocolsRef.current = [];
       const tokenSymbolAndAddress = selectedToken?.toLowerCase();
 
       if (!tokenSymbolAndAddress) {
@@ -309,6 +322,9 @@ export default function IndexOverviews() {
         usdBalance,
         tokenPricesMappingTable,
         handleStatusUpdate,
+        onProtocolsSkipped: (skipped) => {
+          skippedProtocolsRef.current = skipped;
+        },
       };
 
       const handleError = async (error, context) => {
@@ -331,6 +347,9 @@ export default function IndexOverviews() {
         const txns = await generateIntentTxns(actionParams);
         console.log("txns", txns);
         setCostsCalculated(true);
+        // A single txn is a legitimate zapOut result: some protocols withdraw in
+        // one call, and skipping a failing protocol can leave just one behind
+        const minTxnCount = actionName === "zapOut" ? 1 : 2;
         if (
           [
             "zapIn",
@@ -340,7 +359,7 @@ export default function IndexOverviews() {
             "transfer",
             "convertDust",
           ].includes(actionName) &&
-          txns.length < 2
+          txns.length < minTxnCount
         ) {
           throw new Error("No transactions to send");
         }
@@ -385,6 +404,16 @@ export default function IndexOverviews() {
                   })();
                 }
 
+                const skippedNotice =
+                  skippedProtocolsRef.current.length > 0 ? (
+                    <p className="text-sm mt-1 text-amber-500">
+                      {skippedProtocolsRef.current.length} position(s) skipped
+                      and still invested:{" "}
+                      {skippedProtocolsRef.current
+                        .map((skipped) => shortenProtocolId(skipped.uniqueId))
+                        .join(", ")}
+                    </p>
+                  ) : null;
                 const notificationContent = allChainsComplete ? (
                   <div>
                     <p>All Chains Complete</p>
@@ -396,22 +425,26 @@ export default function IndexOverviews() {
                         to convert small balances to ETH.
                       </p>
                     )}
+                    {skippedNotice}
                   </div>
                 ) : (
-                  <div className="flex items-center gap-2">
-                    <div className="flex items-center gap-2 text-sm">
-                      <span className="text-gray-500">Completed on</span>
-                      <div className="flex items-center gap-1">
-                        <Image
-                          src={`/chainPicturesWebp/${currentChain?.toLowerCase()}.webp`}
-                          alt={currentChain}
-                          width={20}
-                          height={20}
-                          className="w-5 h-5 rounded-full"
-                        />
-                        <span className="font-medium">{currentChain}</span>
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-2 text-sm">
+                        <span className="text-gray-500">Completed on</span>
+                        <div className="flex items-center gap-1">
+                          <Image
+                            src={`/chainPicturesWebp/${currentChain?.toLowerCase()}.webp`}
+                            alt={currentChain}
+                            width={20}
+                            height={20}
+                            className="w-5 h-5 rounded-full"
+                          />
+                          <span className="font-medium">{currentChain}</span>
+                        </div>
                       </div>
                     </div>
+                    {skippedNotice}
                   </div>
                 );
                 txnHash =
@@ -572,6 +605,7 @@ export default function IndexOverviews() {
           // chart, but protocols still expect a callable
           updateProgress: () => {},
           uniqueIds,
+          aaOn,
         });
       } catch (error) {
         await reportError(error, "Emergency Exit failed to build");

--- a/utils/dustConversion.js
+++ b/utils/dustConversion.js
@@ -114,7 +114,16 @@ export const handleDustConversion = async ({
   }
 };
 
-export const getTokens = async (chainName, accountAddress) => {
+/**
+ * Raw wallet token list, unfiltered.
+ * Emergency exit must move everything the user holds, including assets the dust
+ * conversion filters intentionally drop (native ETH, unpriced/depegged tokens,
+ * sub-cent balances, aTokens).
+ * @param {string} chainName - Chain name
+ * @param {string} accountAddress - User's wallet address
+ * @returns {Promise<Array>} Token objects as returned by the backend
+ */
+export const fetchWalletTokens = async (chainName, accountAddress) => {
   const response = await fetch(
     `${process.env.NEXT_PUBLIC_API_URL}/user/${accountAddress}/${chainName}/tokens`,
   );
@@ -122,19 +131,22 @@ export const getTokens = async (chainName, accountAddress) => {
     throw new Error("Failed to fetch tokens");
   }
   const data = await response.json();
+  return Array.isArray(data) ? data : [];
+};
+
+export const getTokens = async (chainName, accountAddress) => {
+  const data = await fetchWalletTokens(chainName, accountAddress);
   const filteredAndSortedTokens = data
-    ? data
-        .filter((token) => token.price > 0)
-        .filter(
-          (token) =>
-            !token.optimized_symbol.toLowerCase().includes("-") &&
-            !token.optimized_symbol.toLowerCase().includes("/") &&
-            token.optimized_symbol.toLowerCase() !== "eth" &&
-            token.optimized_symbol.toLowerCase() !== "alp",
-        )
-        .filter((token) => !token.protocol_id.includes("aave"))
-        .filter((token) => token.amount * token.price > 0.005)
-        .sort((a, b) => b.amount * b.price - a.amount * a.price)
-    : [];
+    .filter((token) => token.price > 0)
+    .filter(
+      (token) =>
+        !token.optimized_symbol.toLowerCase().includes("-") &&
+        !token.optimized_symbol.toLowerCase().includes("/") &&
+        token.optimized_symbol.toLowerCase() !== "eth" &&
+        token.optimized_symbol.toLowerCase() !== "alp",
+    )
+    .filter((token) => !token.protocol_id.includes("aave"))
+    .filter((token) => token.amount * token.price > 0.005)
+    .sort((a, b) => b.amount * b.price - a.amount * a.price);
   return filteredAndSortedTokens;
 };


### PR DESCRIPTION
…doubled

Emergency Exit only moved each protocol's receipt/LP token, leaving loose wallet ERC20s, pending rewards, NFT positions and native ETH behind — not enough to actually retreat with. It now hands over everything the app holds for the user on the current chain.

Fixes a pre-existing critical bug found while doing this: protocols with no separate staking contract (Aave, Moonwell, PendlePT) size _unstake off assetBalanceOf and emit no unstake txn, so that amount already *is* the wallet balance. Adding the wallet balance on top asked for twice what the user held and reverted every time, making the escape hatch unusable for those positions. Existing tests missed it because they only covered the LP path, where the staked balance is a genuinely separate number.

Also fixes .add(undefined) when assetBalanceOf reports a burned NFT, and the same double-count for NFT positions (whose assetBalanceOf returns liquidity, not a token count).

Design notes:
- Claiming rewards is best-effort. Forfeiting rewards is survivable; being unable to withdraw principal is not, so a failed claim no longer blocks it.
- Reward amounts ship as their own group, apart from the wallet snapshot. A Debank balance is what the wallet demonstrably holds; a reward amount is what a protocol predicts its claim will pay (Equilibria multiplies out a factor, Camelot reads an API). Summing them would let one bad prediction revert the transfer of tokens the user definitely owns. Vesting entries are excluded outright — nothing can move them yet.
- NFT enumeration is scoped to the protocol's own pool. Several protocols in a vault share one position manager, so an unscoped list made each of their groups try to move all of the wallet's NFTs and only the first succeeded.
- The indiscriminate wallet and native sweeps only run against an AA wallet. In EOA mode the account is the user's own wallet holding unrelated assets; they asked to exit their positions, not to be emptied out.
- A failed wallet scan surfaces as a failed row instead of being logged and dropped, so the panel can never imply the wallet was emptied when it was never read.

zapOut now tolerates a partial batch: it is the only action where each protocol sizes its withdrawal from its own balance with nothing carried between them, so dropping one cannot skew the others' amounts. Skipped positions are named in the success notification rather than silently omitted.

## Description

<!--Describe what the change is**-->

## Checklist:

- [ ] Add test cases to all the changes you introduce
- [ ] Update the documentation if necessary
- [ ] Update ENV on fleek if necessary
- [ ] Use $1 to test the entire pipeline
