### PR TITLE
feat: separate EOA position exit and add Arbitrum executeBatch experi…

### DIFF
--- a/__tests__/utils/eoaFullExit.test.js
+++ b/__tests__/utils/eoaFullExit.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { buildEoaFullExitPlan } from "../../utils/eoaFullExit";
+import {
+  buildEoaFullExitPlan,
+  getEoaFullExitTokenDeltas,
+} from "../../utils/eoaFullExit";
 
 const OWNER = "0xc774806f9fF5f3d8aaBb6b70d0Ed509e42aFE6F0";
 const USDC = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
@@ -14,6 +17,80 @@ const protocol = (uniqueId, result) => ({
         ? vi.fn().mockRejectedValue(result)
         : vi.fn().mockResolvedValue(result),
   },
+});
+
+describe("EOA full exit token deltas", () => {
+  it("only returns the token amount created by the position unwind", () => {
+    const before = [
+      {
+        id: USDC,
+        address: USDC,
+        symbol: "usdc",
+        optimized_symbol: "usdc",
+        decimals: 6,
+        amount: 10,
+        price: 1,
+        raw_amount_hex_str: "0x989680",
+      },
+    ];
+    const after = [
+      {
+        ...before[0],
+        amount: 13.5,
+        raw_amount_hex_str: "0xcdfe60",
+      },
+    ];
+
+    const deltas = getEoaFullExitTokenDeltas({
+      beforeTokens: before,
+      afterTokens: after,
+      expectedTokens: [before[0]],
+    });
+
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0].amount).toBe(3.5);
+    expect(deltas[0].raw_amount_hex_str).toBe("0x3567e0");
+  });
+
+  it("does not include unrelated loose wallet tokens", () => {
+    const unrelated = "0x4200000000000000000000000000000000000006";
+    const deltas = getEoaFullExitTokenDeltas({
+      beforeTokens: [],
+      afterTokens: [
+        {
+          id: USDC,
+          address: USDC,
+          symbol: "usdc",
+          optimized_symbol: "usdc",
+          decimals: 6,
+          amount: 2,
+          price: 1,
+          raw_amount_hex_str: "0x1e8480",
+        },
+        {
+          id: unrelated,
+          address: unrelated,
+          symbol: "weth",
+          optimized_symbol: "weth",
+          decimals: 18,
+          amount: 1,
+          price: 3000,
+          raw_amount_hex_str: "0xde0b6b3a7640000",
+        },
+      ],
+      expectedTokens: [
+        {
+          id: USDC,
+          address: USDC,
+          symbol: "usdc",
+          decimals: 6,
+        },
+      ],
+    });
+
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0].address.toLowerCase()).toBe(USDC.toLowerCase());
+  });
 });
 
 describe("EOA full exit planning", () => {

--- a/pages/aa-exit/index.jsx
+++ b/pages/aa-exit/index.jsx
@@ -119,6 +119,52 @@ const formatAmount = (raw, decimals) =>
 const shortAddress = (address) =>
   `${address.slice(0, 6)}...${address.slice(-4)}`;
 
+const transactionsOfPlannedBatch = (batch) =>
+  (batch?.groups || []).flatMap((group) => (group.txns || []).flat(Infinity));
+
+export const buildArbitrumBatchExperiments = (plan) => {
+  const batches = plan?.batches || [];
+  const batchTransactions = batches.map(transactionsOfPlannedBatch);
+  const allTransactions = batchTransactions.flat();
+  const largestBatch = batchTransactions.reduce(
+    (largest, current) => (current.length > largest.length ? current : largest),
+    [],
+  );
+
+  const prefix = (count) => ({
+    id: `prefix-${count}`,
+    label: `${count} calls`,
+    description: `First ${count} calls from the healthy exit plan`,
+    transactions: allTransactions.slice(0, count),
+    available: allTransactions.length >= count,
+  });
+
+  return [
+    prefix(2),
+    prefix(4),
+    prefix(8),
+    {
+      id: "largest-batch",
+      label: "Largest planned batch",
+      description: "Largest batch produced by the current dry-run planner",
+      transactions: largestBatch,
+      available: largestBatch.length >= 2,
+    },
+    {
+      id: "full-plan",
+      label: "Full healthy plan",
+      description: "Every healthy call combined into one executeBatch",
+      transactions: allTransactions,
+      available: allTransactions.length >= 2,
+    },
+  ];
+};
+
+const batchExperimentError = (error) => {
+  const message = error?.shortMessage || error?.message || String(error);
+  return message.length > 360 ? `${message.slice(0, 357)}...` : message;
+};
+
 function ResultRow({
   row,
   explorerUrl,
@@ -209,6 +255,8 @@ export default function AaExit() {
   const [fellBack, setFellBack] = useState(false);
   const [retrying, setRetrying] = useState(null);
   const [manualDirectMode, setManualDirectMode] = useState(false);
+  const [batchExperimentRunning, setBatchExperimentRunning] = useState(null);
+  const [batchExperimentResults, setBatchExperimentResults] = useState({});
   const [pendingUserOp, setPendingUserOp] = useState(null);
   const [pendingDirectTransaction, setPendingDirectTransaction] =
     useState(null);
@@ -306,6 +354,8 @@ export default function AaExit() {
     setWalletScanFailed(false);
     setUntransferableTokens([]);
     setFellBack(false);
+    setBatchExperimentRunning(null);
+    setBatchExperimentResults({});
     setSubmissionStage("");
     setRecoveredSubmission(null);
     setPendingDirectTransaction(null);
@@ -1053,6 +1103,8 @@ export default function AaExit() {
         statusRef.current[uniqueId] = "failed";
       });
       setFeePlan(result.feePlan);
+      setBatchExperimentRunning(null);
+      setBatchExperimentResults({});
       setWalletScanFailed(!!result.walletScanError);
       setUntransferableTokens(result.untransferableTokens || []);
       setFellBack(
@@ -1092,6 +1144,75 @@ export default function AaExit() {
     notificationAPI,
     chainName,
   ]);
+
+  const handleBatchExperiment = useCallback(
+    async (experiment) => {
+      if (
+        !isArbitrum ||
+        !experiment?.available ||
+        experiment.transactions.length < 2 ||
+        phase !== "ready" ||
+        exitPlanStale
+      ) {
+        return;
+      }
+      const adminAccount = adminWallet?.getAccount();
+      if (!adminAccount?.address || !account?.address) {
+        setBatchExperimentResults((current) => ({
+          ...current,
+          [experiment.id]: {
+            status: "failed",
+            error: "Could not resolve the AA admin account",
+          },
+        }));
+        return;
+      }
+
+      setBatchExperimentRunning(experiment.id);
+      setBatchExperimentResults((current) => ({
+        ...current,
+        [experiment.id]: { status: "running" },
+      }));
+      try {
+        const result = await probeAaBatchDirect({
+          groups: [
+            {
+              uniqueId: `experiment-${experiment.id}`,
+              txns: experiment.transactions,
+            },
+          ],
+          adminAccount,
+          chainMetadata,
+          smartAccountAddress: account.address,
+        });
+        setBatchExperimentResults((current) => ({
+          ...current,
+          [experiment.id]: {
+            status: "success",
+            gas: result.gas?.toString?.() || String(result.gas || "unknown"),
+          },
+        }));
+      } catch (error) {
+        setBatchExperimentResults((current) => ({
+          ...current,
+          [experiment.id]: {
+            status: "failed",
+            error: batchExperimentError(error),
+          },
+        }));
+      } finally {
+        setBatchExperimentRunning(null);
+      }
+    },
+    [
+      account?.address,
+      adminWallet,
+      chainMetadata,
+      exitPlanStale,
+      isArbitrum,
+      phase,
+    ],
+  );
 
   const finishRun = useCallback((status) => {
     if (
@@ -1292,6 +1413,9 @@ export default function AaExit() {
   }
 
   const movableRows = rows.filter((row) => row.txnCount > 0);
+  const batchExperiments = isArbitrum
+    ? buildArbitrumBatchExperiments(planRef.current)
+    : [];
   const aaTransactionsUrl =
     explorerUrl && account?.address
       ? `${explorerUrl}txsAA?f=${account.address}`
@@ -1675,6 +1799,71 @@ export default function AaExit() {
                   </Text>
                 </div>
               )}
+            </Card>
+          )}
+
+          {isArbitrum && phase === "ready" && rows.length > 0 && (
+            <Card title="Arbitrum executeBatch experiments">
+              <Alert
+                className="mb-3"
+                type="info"
+                showIcon
+                message="Simulation only — these buttons do not send transactions"
+                description="Each test builds a real AA.executeBatch from the current healthy exit plan and asks Arbitrum to estimate its gas. ✅ means the batch simulation passed; ❌ shows the revert or RPC error. Your balances and positions are not changed."
+              />
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {batchExperiments.map((experiment) => {
+                  const result = batchExperimentResults[experiment.id];
+                  const running = batchExperimentRunning === experiment.id;
+                  return (
+                    <div
+                      key={experiment.id}
+                      className="rounded-lg border border-gray-200 bg-gray-50 p-3"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <Text strong>{experiment.label}</Text>
+                          <Text type="secondary" className="block text-xs mt-1">
+                            {experiment.description}
+                          </Text>
+                          <Text type="secondary" className="block text-xs mt-1">
+                            {experiment.transactions.length} call
+                            {experiment.transactions.length === 1 ? "" : "s"}
+                          </Text>
+                        </div>
+                        <Button
+                          size="small"
+                          disabled={
+                            !experiment.available ||
+                            exitPlanStale ||
+                            (batchExperimentRunning !== null && !running)
+                          }
+                          loading={running}
+                          onClick={() => handleBatchExperiment(experiment)}
+                        >
+                          Test
+                        </Button>
+                      </div>
+                      {!experiment.available && (
+                        <Text type="secondary" className="block text-xs mt-2">
+                          Not enough calls in this plan.
+                        </Text>
+                      )}
+                      {result?.status === "success" && (
+                        <Text className="block text-xs mt-2 text-green-600">
+                          ✅ executeBatch simulation passed — estimated gas:{" "}
+                          {Number(result.gas).toLocaleString("en-US")}
+                        </Text>
+                      )}
+                      {result?.status === "failed" && (
+                        <Text className="block text-xs mt-2 text-red-600 break-all">
+                          ❌ {result.error}
+                        </Text>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
             </Card>
           )}
 

--- a/pages/dustzap/index.jsx
+++ b/pages/dustzap/index.jsx
@@ -58,6 +58,7 @@ import {
 } from "../../utils/tokenUtils";
 import {
   buildEoaFullExitPlan,
+  getEoaFullExitTokenDeltas,
   refreshEoaFullExitTokens,
 } from "../../utils/eoaFullExit";
 import {
@@ -204,11 +205,13 @@ const HeroSection = ({
   totalValue,
   tokenCount,
   isConverting,
+  activeAction,
   onConvert,
+  onClosePositions,
+  canClosePositions,
   hasTokens,
   slippage,
   onSlippageChange,
-  fullExit = false,
 }) => (
   <div className="relative overflow-hidden">
     {/* Background gradient */}
@@ -234,13 +237,13 @@ const HeroSection = ({
           level={1}
           className="mb-4 bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent"
         >
-          {fullExit ? "Close Everything to ETH" : "Convert Dust to ETH"}
+          Convert Dust to ETH
         </Title>
 
         <Paragraph className="mb-8 text-lg text-gray-600 leading-relaxed">
-          {fullExit
-            ? "Close supported DeFi positions first, then convert the resulting wallet tokens to ETH using fresh on-chain balances."
-            : "Transform your small token balances into valuable ETH with our free, gasless conversion service. Clean up your wallet and maximize your portfolio efficiency."}
+          Transform loose wallet tokens into ETH. On supported EOA chains, you
+          can also close LP, staking, vault, and other supported protocol
+          positions with a separate action below.
         </Paragraph>
 
         {/* Stats */}
@@ -283,23 +286,36 @@ const HeroSection = ({
             />
           </div>
 
-          <Button
-            type="primary"
-            size="large"
-            loading={isConverting}
-            disabled={!fullExit && (!hasTokens || totalValue === 0)}
-            onClick={onConvert}
-            className="h-14 px-12 text-lg font-semibold bg-gradient-to-r from-blue-600 to-purple-600 border-0 hover:from-blue-700 hover:to-purple-700 shadow-xl hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-0.5"
-            icon={<SparklesIcon className="h-5 w-5" />}
-          >
-            {isConverting
-              ? fullExit
-                ? "Closing positions..."
-                : "Converting..."
-              : fullExit
-              ? "Close Positions & Convert All to ETH"
-              : "Convert All Dust to ETH"}
-          </Button>
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Button
+              type="primary"
+              size="large"
+              loading={isConverting && activeAction === "dust"}
+              disabled={isConverting || !hasTokens || totalValue === 0}
+              onClick={onConvert}
+              className="h-14 px-12 text-lg font-semibold bg-gradient-to-r from-blue-600 to-purple-600 border-0 hover:from-blue-700 hover:to-purple-700 shadow-xl hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-0.5"
+              icon={<SparklesIcon className="h-5 w-5" />}
+            >
+              {isConverting && activeAction === "dust"
+                ? "Converting..."
+                : "Convert Wallet Tokens to ETH"}
+            </Button>
+
+            {canClosePositions && (
+              <Button
+                size="large"
+                loading={isConverting && activeAction === "positions"}
+                disabled={isConverting}
+                onClick={onClosePositions}
+                className="h-14 px-12 text-lg font-semibold border-blue-500 text-blue-600 bg-white hover:bg-blue-50 shadow-lg hover:shadow-xl transition-all duration-300"
+                icon={<ArrowPathIcon className="h-5 w-5" />}
+              >
+                {isConverting && activeAction === "positions"
+                  ? "Closing positions..."
+                  : "Close Protocol Positions to ETH"}
+              </Button>
+            )}
+          </div>
         </div>
 
         {/* Service features */}
@@ -617,6 +633,7 @@ export default function DustZap() {
   const [tokens, setTokens] = useState([]);
   const [loading, setLoading] = useState(false);
   const [isConverting, setIsConverting] = useState(false);
+  const [activeAction, setActiveAction] = useState(null);
   const [error, setError] = useState(null);
   const [showDetails, setShowDetails] = useState(false);
   const [statusMessages, setStatusMessages] = useState([]);
@@ -766,7 +783,7 @@ export default function DustZap() {
       ),
     [filteredAndSortedTokens],
   );
-  const eoaFullExitEnabled = useMemo(() => {
+  const eoaPositionExitEnabled = useMemo(() => {
     if (aaOn || !activeChain?.name) return false;
     return ["arbitrum", "base", "op"].includes(
       normalizeChainName(activeChain.name),
@@ -848,14 +865,23 @@ export default function DustZap() {
     }
   };
 
-  const handleConvert = async () => {
+  const handleConvert = async (positionsOnly = false) => {
     if (!account?.address || !activeChain) return;
 
     const chainName = normalizeChainName(activeChain.name);
-    const fullExitEnabled =
-      !aaOn && ["arbitrum", "base", "op"].includes(chainName);
+    const closePositions = positionsOnly && eoaPositionExitEnabled;
+    if (positionsOnly && !closePositions) {
+      openNotificationWithIcon(
+        notificationAPI,
+        "Position Exit Unavailable",
+        "warning",
+        "Protocol position unwinds are currently available for EOA wallets on Arbitrum, Base, and OP.",
+      );
+      return;
+    }
 
     setIsConverting(true);
+    setActiveAction(positionsOnly ? "positions" : "dust");
     setStatusMessages([]);
     setTransactionSigned(false);
     setTotalSteps(filteredAndSortedTokens.length);
@@ -870,14 +896,16 @@ export default function DustZap() {
     setEthPrice(fetchedEthPrice);
 
     try {
-      let conversionTokens = filteredAndSortedTokens;
-      let conversionTotalValue = totalValue;
+      let conversionTokens = positionsOnly ? [] : filteredAndSortedTokens;
+      let conversionTotalValue = positionsOnly ? 0 : totalValue;
       let conversionPriceMapping = {
         eth: fetchedEthPrice,
         weth: fetchedEthPrice,
       };
+      let preparedPositionCount = 0;
+      let positionExecutionFailureCount = 0;
 
-      if (fullExitEnabled) {
+      if (closePositions) {
         setFullExitPhase("Scanning protocol positions…");
         const fullExitPlan = await buildEoaFullExitPlan({
           chainName,
@@ -898,6 +926,7 @@ export default function DustZap() {
             );
           },
         });
+        preparedPositionCount = fullExitPlan.groups.length;
         const runtimeFailures = [];
         setFullExitFailures(fullExitPlan.failures);
         conversionPriceMapping = {
@@ -905,6 +934,14 @@ export default function DustZap() {
           eth: fetchedEthPrice,
           weth: fetchedEthPrice,
         };
+
+        setFullExitPhase("Snapshotting position output balances…");
+        const beforePositionTokens = await refreshEoaFullExitTokens({
+          chainName,
+          owner: account.address,
+          expectedTokens: fullExitPlan.expectedTokens,
+          tokenPricesMappingTable: conversionPriceMapping,
+        });
 
         for (
           let groupIndex = 0;
@@ -936,9 +973,10 @@ export default function DustZap() {
               error: error?.message || String(error),
             };
             runtimeFailures.push(failure);
+            positionExecutionFailureCount = runtimeFailures.length;
             setFullExitFailures([...fullExitPlan.failures, ...runtimeFailures]);
             logger.error(
-              `EOA full exit: ${group.uniqueId} failed during execution`,
+              `EOA position exit: ${group.uniqueId} failed during execution`,
               error,
             );
           }
@@ -955,27 +993,28 @@ export default function DustZap() {
               ? `${runtimeFailures.length} position${
                   runtimeFailures.length === 1 ? "" : "s"
                 } could not be closed. Healthy positions were still processed.`
-              : "Position unwind confirmed. Refreshing actual wallet balances before swapping.",
+              : "Position unwind confirmed. Only newly received output tokens will be converted to ETH.",
           );
         }
 
-        setFullExitPhase("Refreshing actual EOA token balances…");
-        const refreshedTokens = await refreshEoaFullExitTokens({
+        setFullExitPhase("Reading position output balances…");
+        const afterPositionTokens = await refreshEoaFullExitTokens({
           chainName,
           owner: account.address,
-          expectedTokens: [...tokens, ...fullExitPlan.expectedTokens],
+          expectedTokens: fullExitPlan.expectedTokens,
           tokenPricesMappingTable: conversionPriceMapping,
         });
-        setTokens(refreshedTokens);
-        conversionTokens = refreshedTokens.filter(
-          (token) => !deletedTokenIds.has(token.id),
-        );
+        conversionTokens = getEoaFullExitTokenDeltas({
+          beforeTokens: beforePositionTokens,
+          afterTokens: afterPositionTokens,
+          expectedTokens: fullExitPlan.expectedTokens,
+        });
         conversionTotalValue = conversionTokens.reduce(
           (sum, token) => sum + token.amount * token.price,
           0,
         );
         setTotalSteps(conversionTokens.length);
-        setFullExitPhase("Fetching swap routes for resulting tokens…");
+        setFullExitPhase("Fetching swap routes for position outputs…");
       }
 
       // Sunset reliability takes precedence over the 0.01% platform fee in AA
@@ -1009,7 +1048,7 @@ export default function DustZap() {
 
       setFetchingSwapRoutes(false);
       setFullExitPhase(
-        fullExitEnabled ? "Swapping resulting tokens to ETH…" : "",
+        closePositions ? "Swapping position outputs to ETH…" : "",
       );
       setAggregateTradingLoss(totalTradingLoss);
 
@@ -1038,8 +1077,8 @@ export default function DustZap() {
             const isFeeBatch =
               batchIndex === feeInsertionBatch && platformFeeTxns.length > 0;
             const notificationTitle = isLastBatch
-              ? fullExitEnabled
-                ? "Full Exit Complete!"
+              ? closePositions
+                ? "Position Exit Complete!"
                 : "All Dust Conversions Complete!"
               : isFeeBatch
               ? `Platform Fee Charged - Batch ${batchIndex}`
@@ -1106,12 +1145,24 @@ export default function DustZap() {
             });
           });
         }
-      } else if (fullExitEnabled) {
+      } else if (closePositions) {
+        const noPositionsFound = preparedPositionCount === 0;
+        const allPreparedPositionsFailed =
+          preparedPositionCount > 0 &&
+          positionExecutionFailureCount === preparedPositionCount;
         openNotificationWithIcon(
           notificationAPI,
-          "Full Exit Complete",
-          "success",
-          "No remaining ERC20 balances needed a swap after closing positions.",
+          noPositionsFound
+            ? "No Supported Positions Found"
+            : allPreparedPositionsFailed
+            ? "Position Exit Failed"
+            : "Positions Closed",
+          allPreparedPositionsFailed ? "warning" : "success",
+          noPositionsFound
+            ? "No supported LP, staking, vault, or protocol positions were found on this chain."
+            : allPreparedPositionsFailed
+            ? "The supported positions were detected, but none could be closed. Review the position errors and retry."
+            : "The positions were closed and no newly received ERC20 output needed an additional swap.",
         );
       }
 
@@ -1119,7 +1170,7 @@ export default function DustZap() {
         `${process.env.NEXT_PUBLIC_SDK_API_URL}/discord/webhook`,
         {
           errorMsg: `<@648492945938317334> ${account?.address}: ${
-            fullExitEnabled ? "EOA full exit" : "Dust conversion"
+            closePositions ? "EOA position exit" : "Dust conversion"
           } success`,
         },
       );
@@ -1128,6 +1179,7 @@ export default function DustZap() {
       logger.error("Dust conversion failed:", err);
     } finally {
       setIsConverting(false);
+      setActiveAction(null);
       setFetchingSwapRoutes(false);
       setFullExitPhase("");
     }
@@ -1169,18 +1221,20 @@ export default function DustZap() {
           totalValue={totalValue}
           tokenCount={filteredAndSortedTokens.length}
           isConverting={isConverting}
-          onConvert={handleConvert}
+          activeAction={activeAction}
+          onConvert={() => handleConvert(false)}
+          onClosePositions={() => handleConvert(true)}
+          canClosePositions={eoaPositionExitEnabled}
           hasTokens={filteredAndSortedTokens.length > 0}
           slippage={slippage}
           onSlippageChange={setSlippage}
-          fullExit={eoaFullExitEnabled}
         />
 
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
-          {eoaFullExitEnabled && (
+          {eoaPositionExitEnabled && (
             <Alert
-              message="EOA Full Exit"
-              description="Supported DeFi positions are closed first. After those transactions confirm, the wallet is scanned again and the resulting ERC20 balances are converted to ETH."
+              message="Protocol Position Exit"
+              description="The position button is separate from the wallet-token Dust Zap. It closes supported LP, staking, vault, and protocol positions, then swaps only the token balance added by those unwinds to ETH. Existing loose wallet tokens are left untouched."
               type="info"
               showIcon
               className="mb-8"
@@ -1222,23 +1276,22 @@ export default function DustZap() {
           )}
 
           {/* No Tokens State */}
-          {!loading &&
-            !error &&
-            !eoaFullExitEnabled &&
-            filteredAndSortedTokens.length === 0 && (
-              <Card className="text-center shadow-lg border-0 bg-gradient-to-br from-green-50 to-emerald-50">
-                <div className="py-16">
-                  <CheckCircleIcon className="h-16 w-16 text-emerald-500 mx-auto mb-6" />
-                  <Title level={3} className="mb-4 text-gray-800">
-                    All Clean!
-                  </Title>
-                  <Paragraph className="text-gray-600 text-lg">
-                    No dust tokens found in your wallet. Your portfolio is
-                    already optimized!
-                  </Paragraph>
-                </div>
-              </Card>
-            )}
+          {!loading && !error && filteredAndSortedTokens.length === 0 && (
+            <Card className="text-center shadow-lg border-0 bg-gradient-to-br from-green-50 to-emerald-50">
+              <div className="py-16">
+                <CheckCircleIcon className="h-16 w-16 text-emerald-500 mx-auto mb-6" />
+                <Title level={3} className="mb-4 text-gray-800">
+                  No Loose Tokens Found
+                </Title>
+                <Paragraph className="text-gray-600 text-lg">
+                  Your wallet has no dust tokens to convert.
+                  {eoaPositionExitEnabled
+                    ? " You can still scan and close protocol positions with the position button above."
+                    : ""}
+                </Paragraph>
+              </div>
+            </Card>
+          )}
 
           {/* Conversion Progress */}
           {showProgressCard &&

--- a/utils/eoaFullExit.js
+++ b/utils/eoaFullExit.js
@@ -175,6 +175,42 @@ export async function buildEoaFullExitPlan({
   };
 }
 
+export function getEoaFullExitTokenDeltas({
+  beforeTokens = [],
+  afterTokens = [],
+  expectedTokens = [],
+}) {
+  const expectedAddresses = new Set(
+    dedupeTokens(expectedTokens).map((token) => token.address.toLowerCase()),
+  );
+  const beforeByAddress = new Map(
+    dedupeTokens(beforeTokens).map((token) => [
+      token.address.toLowerCase(),
+      ethers.BigNumber.from(token.raw_amount_hex_str || 0),
+    ]),
+  );
+
+  return dedupeTokens(afterTokens)
+    .filter((token) => expectedAddresses.has(token.address.toLowerCase()))
+    .map((token) => {
+      const afterBalance = ethers.BigNumber.from(token.raw_amount_hex_str || 0);
+      const beforeBalance =
+        beforeByAddress.get(token.address.toLowerCase()) ||
+        ethers.BigNumber.from(0);
+      if (afterBalance.lte(beforeBalance)) return null;
+
+      const delta = afterBalance.sub(beforeBalance);
+      const decimals = Number(token.decimals);
+      return {
+        ...token,
+        amount: Number(ethers.utils.formatUnits(delta, decimals)),
+        raw_amount_hex_str: delta.toHexString(),
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.amount * b.price - a.amount * a.price);
+}
+
 export async function refreshEoaFullExitTokens({
   chainName,
   owner,


### PR DESCRIPTION
…ments

Split the DustZap full-exit flow into an explicit protocol-position action that converts only newly received output tokens to ETH, tracked via getEoaFullExitTokenDeltas. Add simulation-only executeBatch tests on the Arbitrum AA exit page.

## Description

<!--Describe what the change is**-->

## Checklist:

- [ ] Add test cases to all the changes you introduce
- [ ] Update the documentation if necessary
- [ ] Update ENV on fleek if necessary
- [ ] Use $1 to test the entire pipeline
