### PR TITLE
fix: safe exit fallback and never-swap token protections

### DIFF
--- a/__tests__/dustConversion.test.js
+++ b/__tests__/dustConversion.test.js
@@ -100,14 +100,15 @@ describe("Dust Conversion Utilities", () => {
       );
 
       // Should filter out:
-      // - USDC, ETH (excluded symbols)
+      // - ETH (excluded symbol)
       // - DUST-TOKEN (contains "-")
       // - AAVE-TOKEN (aave protocol)
       // - SMALL-TOKEN (amount * price < 0.005)
-      // Should include: WBTC, ARB
-      expect(result).toHaveLength(2);
-      expect(result[0].optimized_symbol).toBe("WBTC"); // Higher value, should be first
-      expect(result[1].optimized_symbol).toBe("ARB");
+      // Should include: WBTC, ARB, and the valid USDC balance
+      expect(result).toHaveLength(3);
+      expect(result[0].optimized_symbol).toBe("USDC");
+      expect(result[1].optimized_symbol).toBe("WBTC");
+      expect(result[2].optimized_symbol).toBe("ARB");
     });
 
     it("should handle empty response", async () => {
@@ -311,6 +312,27 @@ describe("Dust Conversion Utilities", () => {
       expect(swap.mock.calls.every((call) => call[15] === providers)).toBe(
         true,
       );
+    });
+
+    it("never builds a swap for denylisted Arbitrum USDX", async () => {
+      const usdx = {
+        optimized_symbol: "USDX",
+        symbol: "USDX",
+        price: 1,
+        amount: 10,
+        decimals: 18,
+        id: "0xb2f30a7c980f052f02563fb518dcc39e6bf38175",
+        raw_amount_hex_str: "0x8ac7230489e80000",
+      };
+
+      await fetchDustConversionRoutes({
+        ...mockParams,
+        tokens: [mockTokens[0], usdx],
+      });
+
+      expect(swap).toHaveBeenCalledTimes(1);
+      expect(swap.mock.calls[0][1]).toBe(42161);
+      expect(swap.mock.calls[0][4]).toBe(mockTokens[0].id);
     });
 
     it("should handle swap failures gracefully", async () => {
@@ -525,8 +547,8 @@ describe("Dust Conversion Utilities", () => {
         handleStatusUpdate: vi.fn(),
       });
 
-      // Should process only ARB (USDC filtered out)
-      expect(result).toHaveLength(1);
+      // Both valid positive-value balances are converted.
+      expect(result).toHaveLength(2);
       expect(result[0]).toHaveProperty("data", "0xswapdata");
       expect(result[0]).toHaveProperty("to", "0xswapcontract");
 
@@ -550,6 +572,7 @@ describe("Dust Conversion Utilities", () => {
           arb: 1.2,
         }),
         expect.any(Function),
+        undefined,
       );
     });
 

--- a/__tests__/intent/aaExitGroups.test.js
+++ b/__tests__/intent/aaExitGroups.test.js
@@ -9,6 +9,7 @@ import {
   buildProtocolGroups,
   clearAaExitWalletTokenCache,
   clearAaExitWalletTokenMemoryCache,
+  collectExitProtocols,
   scanAaExit,
 } from "../../utils/aaExit";
 
@@ -317,6 +318,76 @@ describe("Venus emergencyTransfer", () => {
     expect(venusProtocol().sweptAssetAddress()).toBe(
       venusProtocol().protocolContract.address,
     );
+  });
+});
+
+// This position is in no vault strategy, so buildProtocolGroups reaching it at
+// all depends on the retired list — and these are the only assertions anywhere on
+// the calldata that empties it.
+describe("retired Equilibria position", () => {
+  const PID_45_MARKET = "0xa877a0E177b54A37066c1786F91a1DAb68F094AF";
+  const EQB_ZAP = "0xc7517f481Cc0a645e63f870830A4B2e580421e32";
+  // what poolInfo(45).token returns: the receipt token EqbZap needs approved,
+  // deliberately not the market LP the user ends up with
+  const EQB_RECEIPT_TOKEN = "0xcf12c0268bd3038d7d811d72eb511cf3b050922c";
+  // withdraw(uint256,uint256) on EqbZap, not the single-argument gauge withdraw
+  const EQB_WITHDRAW_SELECTOR = ethers.utils
+    .id("withdraw(uint256,uint256)")
+    .slice(2, 10);
+  // the amount Debank reports staked for the wallet that went unrescued
+  const STAKED = "1412058125";
+
+  const pid45 = () => {
+    const protocol = collectExitProtocols("arbitrum").find(
+      (candidate) => candidate.interface.pidOfEquilibria === 45,
+    );
+    // ethers defines contract methods as non-configurable, so the whole
+    // read-only instance is swapped out
+    protocol.interface.stakeFarmContractInstance = {
+      functions: {
+        poolInfo: vi.fn().mockResolvedValue({ token: EQB_RECEIPT_TOKEN }),
+      },
+    };
+    return protocol;
+  };
+
+  // Matches the withdraw_action Debank proposes for this position exactly
+  it("approves the receipt token, withdraws pid 45 and hands over the market LP", async () => {
+    const protocol = pid45();
+    stub(protocol.interface, { staked: STAKED, wallet: "0" });
+
+    const [group] = await buildProtocolGroups({
+      protocols: [protocol],
+      owner: OWNER,
+      recipient: RECIPIENT,
+    });
+
+    expect(group.txns).toHaveLength(3);
+    expect(group.txns[0].to.toLowerCase()).toBe(EQB_RECEIPT_TOKEN);
+
+    expect(group.txns[1].to).toBe(EQB_ZAP);
+    expect(await encode(group.txns[1])).includes(EQB_WITHDRAW_SELECTOR);
+    expect((await amountIn(group.txns[1])).toString()).toBe(STAKED);
+
+    expect(await encode(group.txns[2])).includes(TRANSFER_SELECTOR);
+    expect(group.txns[2].to).toBe(PID_45_MARKET);
+    expect((await amountIn(group.txns[2])).toString()).toBe(STAKED);
+    // the sweep must skip the market LP this hands over, not the receipt token
+    expect(group.sweptAssetAddress).toBe(PID_45_MARKET);
+  });
+
+  // Every wallet that never entered this pool pays nothing for it being listed
+  it("produces no row for a wallet holding none of it", async () => {
+    const protocol = pid45();
+    stub(protocol.interface, { staked: "0", wallet: "0" });
+
+    expect(
+      await buildProtocolGroups({
+        protocols: [protocol],
+        owner: OWNER,
+        recipient: RECIPIENT,
+      }),
+    ).toEqual([]);
   });
 });
 

--- a/__tests__/intent/emergencyExit.test.js
+++ b/__tests__/intent/emergencyExit.test.js
@@ -4,6 +4,7 @@ import { encode } from "thirdweb";
 import { optimism } from "thirdweb/chains";
 import { getPortfolioHelper } from "../../utils/thirdwebSmartWallet.ts";
 import { fetchWalletTokens } from "../../utils/dustConversion";
+import { collectExitProtocols } from "../../utils/aaExit";
 
 vi.mock("../../utils/dustConversion", async (importOriginal) => ({
   ...(await importOriginal()),
@@ -670,6 +671,36 @@ describe("emergencyTransfer", () => {
 
     expect(txns).toHaveLength(2);
     expect(await encode(txns[1])).includes(word("1000"));
+  });
+});
+
+describe("fullExitUnwind safe fallback", () => {
+  it("unstakes an expired position and does not expose its LP token to swaps", async () => {
+    const protocol = collectExitProtocols("arbitrum").find(
+      (entry) => entry.interface.pidOfEquilibria === 45,
+    ).interface;
+    vi.spyOn(protocol, "_unstake").mockResolvedValue([
+      ["unstake-expired-lp"],
+      ethers.BigNumber.from("1000"),
+    ]);
+    vi.spyOn(protocol, "assetBalanceOf").mockResolvedValue(
+      ethers.constants.Zero,
+    );
+    vi.spyOn(protocol, "customWithdrawAndClaim").mockRejectedValue(
+      new Error("Pendle route unavailable"),
+    );
+
+    const result = await protocol.fullExitUnwind(OWNER, 1, {}, noop);
+
+    expect(result.txns).toEqual(["unstake-expired-lp"]);
+    expect(result.expectedTokens).toEqual([]);
+    expect(result.keptTokens).toEqual([
+      expect.objectContaining({
+        address: protocol.assetContract.address,
+        keptInWallet: true,
+      }),
+    ]);
+    expect(result.safeExit).toBe(true);
   });
 });
 

--- a/__tests__/utils/aaExit.test.js
+++ b/__tests__/utils/aaExit.test.js
@@ -130,6 +130,51 @@ describe("collectExitProtocols", () => {
   it("returns nothing for a chain no vault covers", () => {
     expect(collectExitProtocols("metis")).toEqual([]);
   });
+
+  // Walking the vault strategies is the only position discovery this page has —
+  // Debank is consulted for loose ERC20s alone — so a pool commented out of or
+  // deleted from a strategy leaves funded positions unreachable. pid 45 was
+  // commented out with ~$3.2k still in it, pid 53 was the whole BTC Vault.
+  it("includes staked positions no vault strategy lists any more", () => {
+    const byPid = new Map(
+      collectExitProtocols("arbitrum")
+        .filter((protocol) => protocol.interface.pidOfEquilibria !== undefined)
+        .map((protocol) => [protocol.interface.pidOfEquilibria, protocol]),
+    );
+
+    expect(byPid.get(45)?.interface.assetContract.address.toLowerCase()).toBe(
+      "0xa877a0e177b54a37066c1786f91a1dab68f094af",
+    );
+    expect(byPid.get(53)?.interface.assetContract.address.toLowerCase()).toBe(
+      "0x8cab5fd029ae2fbf28c53e965e4194c7260adf0c",
+    );
+  });
+
+  // BaseVelodromeV3._getAllNftIDs filters by token pair and tick range, so unlike
+  // Camelot's manager-wide sweep the position still in EthVault cannot reach this
+  // one even though both share an NFT manager
+  it("includes a retired aerodrome v3 range the live position cannot sweep", () => {
+    const retired = collectExitProtocols("base").find(
+      (protocol) =>
+        protocol.interface.customParams?.tickers?.tickLower === 1411,
+    );
+
+    expect(retired).toBeDefined();
+    expect(retired.interface.assetIsNFT).toBe(true);
+    expect(retired.interface.customParams.guageAddress.toLowerCase()).toBe(
+      "0x4197186d3d65f694018ae4b80355225ce1dd64ad",
+    );
+  });
+
+  it("keeps a retired position off the chains it never lived on", () => {
+    ["base", "op"].forEach((chainName) =>
+      expect(
+        collectExitProtocols(chainName).some((protocol) =>
+          [45, 53].includes(protocol.interface.pidOfEquilibria),
+        ),
+      ).toBe(false),
+    );
+  });
 });
 
 describe("debankChainCode", () => {

--- a/__tests__/utils/aaExit.test.js
+++ b/__tests__/utils/aaExit.test.js
@@ -150,6 +150,81 @@ describe("collectExitProtocols", () => {
     );
   });
 
+  it("covers the retired direct PT and common Arbitrum Aave V3 positions", () => {
+    const protocols = collectExitProtocols("arbitrum");
+    const assetAddresses = new Set(
+      protocols.map((entry) =>
+        entry.interface.assetContract?.address?.toLowerCase(),
+      ),
+    );
+
+    expect(assetAddresses).toContain(
+      "0x2be6fab4d1408e7ad6ad91ce7b77fa2a7670782f",
+    );
+    expect(assetAddresses).toContain(
+      "0x724dc807b04555b71ed48a6896b6f41593b8c637",
+    );
+    expect(assetAddresses).toContain(
+      "0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8",
+    );
+  });
+
+  it("locks historical Arbitrum staking coverage into the registry", () => {
+    const protocols = collectExitProtocols("arbitrum").map(
+      (entry) => entry.interface,
+    );
+    const sortedNumbers = (values) => [...values].sort((a, b) => a - b);
+
+    expect(
+      sortedNumbers(
+        protocols
+          .map((protocol) => protocol.pidOfEquilibria)
+          .filter((pid) => pid !== undefined),
+      ),
+    ).toEqual([7, 8, 43, 44, 45, 47, 48, 52, 53, 55, 56, 57, 59]);
+    expect(
+      sortedNumbers(
+        protocols
+          .filter((protocol) => protocol.protocolName === "aura")
+          .map((protocol) => protocol.customParams.pid),
+      ),
+    ).toEqual([69, 93, 94]);
+    expect(
+      sortedNumbers(
+        protocols
+          .filter((protocol) => protocol.protocolName === "convex")
+          .map((protocol) => protocol.pid),
+      ),
+    ).toEqual([28, 34, 36]);
+  });
+
+  it("locks Base Aave and Moonwell exit assets into the registry", () => {
+    const protocols = collectExitProtocols("base").map(
+      (entry) => entry.interface,
+    );
+    const assetsFor = (protocolName) =>
+      new Set(
+        protocols
+          .filter((protocol) => protocol.protocolName === protocolName)
+          .map((protocol) => protocol.assetContract.address.toLowerCase()),
+      );
+
+    expect(assetsFor("aave")).toEqual(
+      new Set([
+        "0x4e65fe4dba92790696d040ac24aa414708f5c0ab",
+        "0xd4a0e0b9149bcee3c920d2e00b5de09138fd8bb7",
+      ]),
+    );
+    expect(assetsFor("moonwell")).toEqual(
+      new Set([
+        "0xb682c840b5f4fc58b20769e691a6fa1305a501a2",
+        "0x73b06d8d18de422e269645eace15400de7462417",
+        "0xedc817a28e8b93b03976fbd4a3ddbc9f7d176c22",
+        "0x627fe393bc6edda28e99ae648fd6ff362514304b",
+      ]),
+    );
+  });
+
   // BaseVelodromeV3._getAllNftIDs filters by token pair and tick range, so unlike
   // Camelot's manager-wide sweep the position still in EthVault cannot reach this
   // one even though both share an NFT manager

--- a/__tests__/utils/eoaFullExit.test.js
+++ b/__tests__/utils/eoaFullExit.test.js
@@ -179,4 +179,44 @@ describe("EOA full exit planning", () => {
     expect(plan.expectedTokens).toHaveLength(1);
     expect(plan.expectedTokens[0].optimized_symbol).toBe("usdc");
   });
+
+  it("uses a safe unstake fallback and keeps its position token out of swaps", async () => {
+    const positionToken = "0xa877a0E177b54A37066c1786F91a1DAb68F094AF";
+    const broken = protocol(
+      "arbitrum/equilibria/expired",
+      new Error("Pendle route unavailable"),
+    );
+    broken.interface.safeExitToWallet = vi.fn().mockResolvedValue({
+      txns: ["unstake-only"],
+      expectedTokens: [],
+      keptTokens: [
+        {
+          id: positionToken,
+          address: positionToken,
+          symbol: "pendle-lp",
+          optimized_symbol: "pendle-lp",
+          decimals: 18,
+        },
+      ],
+      safeExit: true,
+      fallbackReason: "Pendle route unavailable",
+    });
+
+    const plan = await buildEoaFullExitPlan({
+      chainName: "arbitrum",
+      owner: OWNER,
+      slippage: 1,
+      protocols: [broken],
+    });
+
+    expect(plan.groups[0].txns).toEqual(["unstake-only"]);
+    expect(plan.expectedTokens).toEqual([]);
+    expect(plan.keptTokens[0].address.toLowerCase()).toBe(
+      positionToken.toLowerCase(),
+    );
+    expect(plan.fallbacks).toEqual([
+      expect.objectContaining({ safeExit: true }),
+    ]);
+    expect(plan.failures).toEqual([]);
+  });
 });

--- a/__tests__/utils/retiredExitPositions.test.js
+++ b/__tests__/utils/retiredExitPositions.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { AA_EXIT_CHAINS, AA_EXIT_VAULTS } from "../../utils/aaExit";
+import {
+  RETIRED_POSITION_COUNT,
+  retiredExitPositions,
+} from "../../utils/retiredExitPositions";
+import { getPortfolioHelper } from "../../utils/thirdwebSmartWallet.ts";
+
+const vaultUniqueIdsOn = (chainName) =>
+  new Set(
+    AA_EXIT_VAULTS.flatMap((vaultName) =>
+      Object.values(getPortfolioHelper(vaultName)?.strategy || {}).flatMap(
+        (categories) =>
+          Object.entries(categories || {})
+            .filter(([chainKey]) => chainKey.toLowerCase() === chainName)
+            .flatMap(([, list]) =>
+              (list || []).map((protocol) => protocol.interface.uniqueId()),
+            ),
+      ),
+    ),
+  );
+
+const everyRetiredPosition = () =>
+  AA_EXIT_CHAINS.flatMap((chainName) => retiredExitPositions(chainName));
+
+describe("retiredExitPositions", () => {
+  // A retired entry that has come back into a vault strategy is dead weight, and
+  // collectExitProtocols would dedupe it away silently — leaving a stale copy of
+  // its parameters here for whoever reads the list next
+  it("lists nothing a vault strategy already covers", () => {
+    AA_EXIT_CHAINS.forEach((chainName) => {
+      const fromVaults = vaultUniqueIdsOn(chainName);
+      retiredExitPositions(chainName).forEach((position) =>
+        expect(fromVaults.has(position.uniqueId())).toBe(false),
+      );
+    });
+  });
+
+  // A position retired onto a chain the page never scans can never be rescued,
+  // so it would read as covered while being unreachable
+  it("strands nothing on a chain the exit page cannot scan", () => {
+    expect(everyRetiredPosition()).toHaveLength(RETIRED_POSITION_COUNT);
+  });
+
+  // The whole list is built on every scan, so one bad constructor would be a
+  // warning in the console rather than a visible failure
+  it("builds every position without throwing", () => {
+    everyRetiredPosition().forEach((position) => {
+      expect(position.uniqueId()).toBeTruthy();
+      expect(position.chain).toBeTruthy();
+    });
+  });
+
+  // The exit hands over whatever sweptAssetAddress names, so a wrong or missing
+  // asset address moves the wrong token (NFT positions report null by design)
+  it("knows which asset each position hands over", () => {
+    everyRetiredPosition().forEach((position) => {
+      const asset = position.sweptAssetAddress();
+      if (position.assetIsNFT) {
+        expect(asset).toBeNull();
+      } else {
+        expect(asset).toMatch(/^0x[0-9a-fA-F]{40}$/);
+      }
+    });
+  });
+});

--- a/classes/Aave/BaseAave.js
+++ b/classes/Aave/BaseAave.js
@@ -1,9 +1,8 @@
 import AToken from "../../lib/contracts/Aave/Atoken.json" assert { type: "json" };
 import L2PoolInstance from "../../lib/contracts/Aave/L2PoolInstance.json" assert { type: "json" };
-import { base } from "thirdweb/chains";
 import axios from "axios";
 import { ethers } from "ethers";
-import { PROVIDER } from "../../utils/general.js";
+import { CHAIN_ID_TO_CHAIN, PROVIDER } from "../../utils/general.js";
 import axiosRetry from "axios-retry";
 import { getContract, prepareContractCall } from "thirdweb";
 import THIRDWEB_CLIENT from "../../utils/thirdweb.js";
@@ -20,19 +19,19 @@ export class BaseAave extends BaseProtocol {
     this.assetContract = getContract({
       client: THIRDWEB_CLIENT,
       address: customParams.assetAddress,
-      chain: base,
+      chain: CHAIN_ID_TO_CHAIN[this.chainId],
       abi: AToken,
     });
     this.protocolContract = getContract({
       client: THIRDWEB_CLIENT,
       address: customParams.protocolAddress,
-      chain: base,
+      chain: CHAIN_ID_TO_CHAIN[this.chainId],
       abi: L2PoolInstance,
     });
     this.stakeFarmContract = getContract({
       client: THIRDWEB_CLIENT,
       address: customParams.protocolAddress,
-      chain: base,
+      chain: CHAIN_ID_TO_CHAIN[this.chainId],
       abi: L2PoolInstance,
     });
     this.assetContractInstance = new ethers.Contract(

--- a/classes/BaseProtocol.js
+++ b/classes/BaseProtocol.js
@@ -660,6 +660,74 @@ export default class BaseProtocol extends BaseUniswap {
     }
   }
 
+  _fullExitPositionToken() {
+    const address = this.assetContract?.address;
+    if (!address || !ethers.utils.isAddress(address)) return null;
+    const symbol = String(
+      this.symbolList?.join("-") || "position",
+    ).toLowerCase();
+    return {
+      id: address,
+      address,
+      symbol,
+      optimized_symbol: symbol,
+      decimals: Number(this.assetDecimals),
+      keptInWallet: true,
+    };
+  }
+
+  // Build the safest possible exit when a protocol's downstream redemption or
+  // liquidity route cannot be prepared. Staked receipt/LP tokens are returned
+  // to the EOA, while already-loose receipt tokens are left untouched. These
+  // tokens are reported separately and are never offered to the swap stage.
+  async safeExitToWallet(
+    owner,
+    updateProgress = () => {},
+    cause,
+    prepared = {},
+  ) {
+    let unstakeTxns = prepared.unstakeTxns;
+    let unstakedAmount = prepared.unstakedAmount;
+    if (!unstakeTxns) {
+      if (this.assetIsNFT) {
+        return {
+          txns: [],
+          expectedTokens: [],
+          keptTokens: [],
+          safeExit: false,
+          fallbackReason:
+            cause?.message || String(cause || "manual exit required"),
+        };
+      }
+      [unstakeTxns, unstakedAmount] =
+        this.mode === "LP"
+          ? await this._unstakeLP(owner, 1, updateProgress)
+          : await this._unstake(owner, 1, updateProgress);
+    }
+
+    const amount = ethers.BigNumber.from(unstakedAmount || 0);
+    const effectiveUnstakeTxns = amount.isZero() ? [] : unstakeTxns || [];
+    const walletBalance = prepared.totalAmount
+      ? ethers.BigNumber.from(prepared.totalAmount)
+      : amount.add((await this.assetBalanceOf(owner)) || 0);
+    const keptToken = walletBalance.isZero()
+      ? null
+      : this._fullExitPositionToken();
+
+    logger.warn(
+      `${this.uniqueId()}: full unwind unavailable; keeping the position token in the wallet`,
+      cause,
+    );
+    return {
+      txns: effectiveUnstakeTxns,
+      expectedTokens: [],
+      keptTokens: keptToken ? [keptToken] : [],
+      safeExit: effectiveUnstakeTxns.length > 0,
+      fallbackReason:
+        cause?.message || String(cause || "full unwind unavailable"),
+    };
+  }
+
   // EOA full exit: turn a protocol position into ordinary wallet tokens, but do
   // not swap them yet. The caller waits for these txns to confirm, re-reads the
   // actual wallet balances, then builds swaps from those balances. This avoids
@@ -782,46 +850,54 @@ export default class BaseProtocol extends BaseUniswap {
 
     let withdrawTxns = [];
     let expectedTokens = [];
-    if (this.mode === "single") {
-      const [protocolTxns, symbol, address, decimals] =
-        await this.customWithdrawAndClaim(
-          owner,
-          totalAmount,
-          slippage,
-          tokenPricesMappingTable,
-          updateProgress,
-        );
-      withdrawTxns = protocolTxns || [];
-      if (address && ethers.utils.isAddress(address)) {
-        expectedTokens.push({
-          id: address,
-          address,
-          symbol: String(symbol || "").toLowerCase(),
-          optimized_symbol: String(symbol || "").toLowerCase(),
-          decimals: Number(decimals),
-        });
+    try {
+      if (this.mode === "single") {
+        const [protocolTxns, symbol, address, decimals] =
+          await this.customWithdrawAndClaim(
+            owner,
+            totalAmount,
+            slippage,
+            tokenPricesMappingTable,
+            updateProgress,
+          );
+        withdrawTxns = protocolTxns || [];
+        if (address && ethers.utils.isAddress(address)) {
+          expectedTokens.push({
+            id: address,
+            address,
+            symbol: String(symbol || "").toLowerCase(),
+            optimized_symbol: String(symbol || "").toLowerCase(),
+            decimals: Number(decimals),
+          });
+        }
+      } else {
+        const [protocolTxns, tokenMetadatas] =
+          await this.customWithdrawLPAndClaim(
+            owner,
+            totalAmount,
+            slippage,
+            tokenPricesMappingTable,
+            updateProgress,
+          );
+        withdrawTxns = protocolTxns || [];
+        expectedTokens = (tokenMetadatas || [])
+          .filter(
+            (metadata) => metadata?.[1] && ethers.utils.isAddress(metadata[1]),
+          )
+          .map(([symbol, address, decimals]) => ({
+            id: address,
+            address,
+            symbol: String(symbol || "").toLowerCase(),
+            optimized_symbol: String(symbol || "").toLowerCase(),
+            decimals: Number(decimals),
+          }));
       }
-    } else {
-      const [protocolTxns, tokenMetadatas] =
-        await this.customWithdrawLPAndClaim(
-          owner,
-          totalAmount,
-          slippage,
-          tokenPricesMappingTable,
-          updateProgress,
-        );
-      withdrawTxns = protocolTxns || [];
-      expectedTokens = (tokenMetadatas || [])
-        .filter(
-          (metadata) => metadata?.[1] && ethers.utils.isAddress(metadata[1]),
-        )
-        .map(([symbol, address, decimals]) => ({
-          id: address,
-          address,
-          symbol: String(symbol || "").toLowerCase(),
-          optimized_symbol: String(symbol || "").toLowerCase(),
-          decimals: Number(decimals),
-        }));
+    } catch (error) {
+      return this.safeExitToWallet(owner, updateProgress, error, {
+        unstakeTxns: effectiveUnstakeTxns,
+        unstakedAmount: unstakedAmountBN,
+        totalAmount,
+      });
     }
 
     const txns = [...effectiveUnstakeTxns, ...withdrawTxns];
@@ -864,7 +940,7 @@ export default class BaseProtocol extends BaseUniswap {
     slippage,
     updateProgress,
   ) {
-    throw new Error("Method 'customDeposit()' must be implemented.", amount);
+    throw new Error("Method 'customDeposit()' must be implemented.");
   }
   async baseWithdrawAndClaim(
     owner,

--- a/pages/dustzap/index.jsx
+++ b/pages/dustzap/index.jsx
@@ -26,7 +26,11 @@ import {
   useSendAndConfirmCalls,
   useSwitchActiveWalletChain,
 } from "thirdweb/react";
-import { getTokens } from "../../utils/dustConversion";
+import {
+  fetchWalletTokens,
+  getTokens,
+  isNeverSwapToken,
+} from "../../utils/dustConversion";
 import { transformToDebankChainName } from "../../utils/chainHelper";
 import { handleDustConversion } from "../../utils/dustConversion";
 import ImageWithFallback from "../basicComponents/ImageWithFallback";
@@ -655,6 +659,7 @@ export default function DustZap() {
   const [aggregateTradingLoss, setAggregateTradingLoss] = useState(0);
   const [fullExitPhase, setFullExitPhase] = useState("");
   const [fullExitFailures, setFullExitFailures] = useState([]);
+  const [fullExitFallbacks, setFullExitFallbacks] = useState([]);
 
   const statusMessagesRef = useRef([]);
 
@@ -774,10 +779,21 @@ export default function DustZap() {
   }, [account?.address, activeChain?.name]);
 
   // =============== COMPUTED VALUES ===============
+  const neverSwapTokens = useMemo(() => {
+    const baseFiltered = getFilteredAndSortedTokens(tokens);
+    return baseFiltered.filter((token) =>
+      isNeverSwapToken(activeChain?.id, token.id || token.address),
+    );
+  }, [tokens, activeChain?.id]);
+
   const filteredAndSortedTokens = useMemo(() => {
     const baseFiltered = getFilteredAndSortedTokens(tokens);
-    return baseFiltered.filter((token) => !deletedTokenIds.has(token.id));
-  }, [tokens, deletedTokenIds]);
+    return baseFiltered.filter(
+      (token) =>
+        !deletedTokenIds.has(token.id) &&
+        !isNeverSwapToken(activeChain?.id, token.id || token.address),
+    );
+  }, [tokens, deletedTokenIds, activeChain?.id]);
 
   const totalValue = useMemo(
     () =>
@@ -892,6 +908,7 @@ export default function DustZap() {
     setShowProgressCard(true);
     setFetchingSwapRoutes(true);
     setFullExitFailures([]);
+    setFullExitFallbacks([]);
 
     const priceService = new PriceService(process.env.NEXT_PUBLIC_API_URL);
     const fetchedEthPrice = await priceService.fetchPrice("eth", {
@@ -911,11 +928,23 @@ export default function DustZap() {
 
       if (closePositions) {
         setFullExitPhase("Scanning protocol positions…");
+        let rawWalletTokens = tokens;
+        try {
+          rawWalletTokens = await fetchWalletTokens(
+            transformToDebankChainName(activeChain.name.toLowerCase()),
+            account.address,
+          );
+        } catch (rawTokenError) {
+          logger.warn(
+            "EOA position exit: raw wallet discovery failed; continuing with loaded tokens",
+            rawTokenError,
+          );
+        }
         const fullExitPlan = await buildEoaFullExitPlan({
           chainName,
           owner: account.address,
           slippage,
-          walletTokens: tokens,
+          walletTokens: rawWalletTokens,
           ethPrice: fetchedEthPrice,
           onProgress: ({
             completed,
@@ -933,6 +962,7 @@ export default function DustZap() {
         preparedPositionCount = fullExitPlan.groups.length;
         const runtimeFailures = [];
         setFullExitFailures(fullExitPlan.failures);
+        setFullExitFallbacks(fullExitPlan.fallbacks);
         conversionPriceMapping = {
           ...fullExitPlan.tokenPricesMappingTable,
           eth: fetchedEthPrice,
@@ -1250,6 +1280,39 @@ export default function DustZap() {
               message="Protocol Position Exit"
               description="The position button is separate from the wallet-token Dust Zap. It closes supported LP, staking, vault, and protocol positions, then swaps only the token balance added by those unwinds to ETH. Existing loose wallet tokens are left untouched."
               type="info"
+              showIcon
+              className="mb-8"
+            />
+          )}
+
+          {neverSwapTokens.length > 0 && (
+            <Alert
+              message="Claimable asset kept in wallet"
+              description={`${neverSwapTokens
+                .map((token) => getTokenSymbol(token))
+                .join(", ")} will not be swapped by DustZap.`}
+              type="warning"
+              showIcon
+              className="mb-8"
+            />
+          )}
+
+          {fullExitFallbacks.length > 0 && (
+            <Alert
+              message={`${fullExitFallbacks.length} position${
+                fullExitFallbacks.length === 1 ? "" : "s"
+              } kept in a safe form`}
+              description={fullExitFallbacks
+                .map(
+                  (fallback) =>
+                    `${fallback.label}: ${
+                      fallback.safeExit
+                        ? "unstaked position token kept in wallet"
+                        : "left untouched for manual handling"
+                    }`,
+                )
+                .join(" • ")}
+              type="warning"
               showIcon
               className="mb-8"
             />

--- a/utils/aaExit.js
+++ b/utils/aaExit.js
@@ -42,6 +42,7 @@ import {
   designateWalletBalanceSweepers,
   sharedExitAssets,
 } from "./exitAssetOwnership";
+import { retiredExitPositions } from "./retiredExitPositions";
 import logger from "./logger";
 
 // Every vault a user can actually enter. Test-only vaults are excluded: their
@@ -708,17 +709,48 @@ async function fetchAaExitWalletTokens(
 }
 
 /**
- * Every protocol on `chainName` across every production vault, deduped.
+ * Every protocol on `chainName` across every production vault, plus the positions
+ * no vault lists any more, deduped.
  * Index vaults build their own instances of the component vaults' protocols, so
  * the same position appears more than once and must be deduped by uniqueId
  * string — object identity does not hold. Sending its transfer twice would ask
  * for twice the balance and revert.
  * `weight` is ignored on purpose: a deprecated protocol is zeroed out while
- * still holding user funds, which is exactly who needs this page.
+ * still holding user funds, which is exactly who needs this page — and a pool
+ * taken out of a strategy entirely is reachable only through
+ * retiredExitPositions.
  */
 export function collectExitProtocols(chainName) {
   const seen = new Set();
   const protocols = [];
+  const add = (protocolInterface) => {
+    const uniqueId = protocolInterface.uniqueId();
+    // Camelot V3 uses one shared NFT position manager for every pool. An
+    // emergency exit must sweep the manager itself, not only the pool/range
+    // combinations that happen to remain in today's vault config. Keep one
+    // representative protocol instance per manager so every owned Camelot
+    // NFT is transferred exactly once, including old/manual positions.
+    const camelotManager =
+      protocolInterface.protocolName === "camelot" &&
+      protocolInterface.assetIsNFT
+        ? protocolInterface.assetContract?.address?.toLowerCase()
+        : null;
+    const dedupeKey = camelotManager
+      ? `camelot-manager:${camelotManager}`
+      : uniqueId;
+    if (seen.has(dedupeKey)) return;
+    seen.add(dedupeKey);
+    protocols.push({
+      uniqueId: camelotManager
+        ? `${chainName}/camelot/v3/all-positions`
+        : uniqueId,
+      label: camelotManager
+        ? "Camelot V3 positions"
+        : protocolInterface.toString(),
+      interface: protocolInterface,
+    });
+  };
+
   for (const vaultName of AA_EXIT_VAULTS) {
     let portfolio;
     try {
@@ -731,36 +763,16 @@ export function collectExitProtocols(chainName) {
     for (const categories of Object.values(portfolio.strategy || {})) {
       for (const [chainKey, list] of Object.entries(categories || {})) {
         if (chainKey.toLowerCase() !== chainName) continue;
-        for (const protocol of list || []) {
-          const uniqueId = protocol.interface.uniqueId();
-          // Camelot V3 uses one shared NFT position manager for every pool. An
-          // emergency exit must sweep the manager itself, not only the pool/range
-          // combinations that happen to remain in today's vault config. Keep one
-          // representative protocol instance per manager so every owned Camelot
-          // NFT is transferred exactly once, including old/manual positions.
-          const camelotManager =
-            protocol.interface.protocolName === "camelot" &&
-            protocol.interface.assetIsNFT
-              ? protocol.interface.assetContract?.address?.toLowerCase()
-              : null;
-          const dedupeKey = camelotManager
-            ? `camelot-manager:${camelotManager}`
-            : uniqueId;
-          if (seen.has(dedupeKey)) continue;
-          seen.add(dedupeKey);
-          protocols.push({
-            uniqueId: camelotManager
-              ? `${chainName}/camelot/v3/all-positions`
-              : uniqueId,
-            label: camelotManager
-              ? "Camelot V3 positions"
-              : protocol.interface.toString(),
-            interface: protocol.interface,
-          });
-        }
+        for (const protocol of list || []) add(protocol.interface);
       }
     }
   }
+
+  // Last on purpose: a pool that comes back into a vault strategy wins the
+  // dedupe, so the retired list may lag behind a re-enable without ever making
+  // the page scan the same position twice.
+  for (const position of retiredExitPositions(chainName)) add(position);
+
   return protocols;
 }
 

--- a/utils/dustConversion.js
+++ b/utils/dustConversion.js
@@ -4,6 +4,20 @@ import swap from "./swapHelper";
 const BATCH_SIZE = 10; // Process 3 tokens at a time to avoid rate limits
 const DELAY_BETWEEN_BATCHES = 1000; // 1 second delay between batches
 
+// Assets in this list must remain claimable in the user's wallet. This is an
+// address-level last line of defence: protocol outputs and loose wallet tokens
+// both eventually pass through fetchDustConversionRoutes, so neither a symbol
+// typo nor a future caller can accidentally route them into an aggregator.
+export const NEVER_SWAP_TOKENS = {
+  42161: new Set(["0xb2f30a7c980f052f02563fb518dcc39e6bf38175"]),
+};
+
+export const isNeverSwapToken = (chainId, address) =>
+  Boolean(
+    address &&
+      NEVER_SWAP_TOKENS[Number(chainId)]?.has(String(address).toLowerCase()),
+  );
+
 /**
  * Fetches swap routes for a batch of tokens
  * @param {Object} params
@@ -24,10 +38,21 @@ export const fetchDustConversionRoutes = async ({
 }) => {
   const allTxns = [];
   let totalTradingLoss = 0;
+  const swappableTokens = (tokens || []).filter((token) => {
+    const address = token?.id || token?.address;
+    if (!isNeverSwapToken(chainId, address)) return true;
+    logger.warn(
+      `Keeping ${
+        token?.symbol || token?.optimized_symbol || address
+      } in wallet: token is on the DustZap never-swap list`,
+    );
+    return false;
+  });
+
   // Process tokens in batches
   // Ambire wallet cannot support too large batch
-  for (let i = 0; i < tokens.length; i += BATCH_SIZE) {
-    const batch = tokens.slice(i, i + BATCH_SIZE);
+  for (let i = 0; i < swappableTokens.length; i += BATCH_SIZE) {
+    const batch = swappableTokens.slice(i, i + BATCH_SIZE);
     // Process each batch concurrently
     const batchPromises = batch.map(async (token) => {
       try {
@@ -70,7 +95,7 @@ export const fetchDustConversionRoutes = async ({
     });
 
     // Wait before processing next batch
-    if (i + BATCH_SIZE < tokens.length) {
+    if (i + BATCH_SIZE < swappableTokens.length) {
       await new Promise((resolve) =>
         setTimeout(resolve, DELAY_BETWEEN_BATCHES),
       );

--- a/utils/eoaFullExit.js
+++ b/utils/eoaFullExit.js
@@ -1,9 +1,11 @@
 import { ethers } from "ethers";
 import ERC20_ABI from "../lib/contracts/ERC20.json" assert { type: "json" };
+import AToken from "../lib/contracts/Aave/Atoken.json" assert { type: "json" };
 import { PriceService, TokenPriceBatcher } from "../classes/TokenPriceService";
+import { BaseAave } from "../classes/Aave/BaseAave";
 import { collectExitProtocols, debankChainCode } from "./aaExit";
 import { fetchWalletTokens } from "./dustConversion";
-import { PROVIDER } from "./general";
+import { CHAIN_TO_CHAIN_ID, PROVIDER } from "./general";
 import logger from "./logger";
 
 const noop = () => {};
@@ -39,6 +41,79 @@ const mapInBatches = async (items, batchSize, mapper) => {
   }
   return results;
 };
+
+// Aave receipt tokens are self-describing: POOL() identifies the pool and
+// UNDERLYING_ASSET_ADDRESS() identifies what withdraw() must redeem. Discovering
+// them from the raw wallet token list prevents a deleted vault config from
+// making an otherwise valid Aave V3 position unreachable.
+export async function discoverAaveWalletPositions({
+  chainName,
+  walletTokens = [],
+  protocols = [],
+}) {
+  const chainId = CHAIN_TO_CHAIN_ID[chainName];
+  if (!chainId) return [];
+  const knownAssets = new Set(
+    protocols
+      .filter((entry) => entry.interface?.protocolName === "aave")
+      .map((entry) => entry.interface.assetContract?.address?.toLowerCase())
+      .filter(Boolean),
+  );
+  const candidates = dedupeTokens(walletTokens).filter((token) => {
+    const protocolId = String(token?.protocol_id || "").toLowerCase();
+    const address = token.address.toLowerCase();
+    return protocolId.includes("aave") && !knownAssets.has(address);
+  });
+  const provider = PROVIDER(chainName);
+
+  const discovered = await mapInBatches(
+    candidates,
+    READ_CONCURRENCY,
+    async (token) => {
+      try {
+        const receipt = new ethers.Contract(token.address, AToken, provider);
+        const [underlyingAddress, poolAddress] = await Promise.all([
+          receipt.UNDERLYING_ASSET_ADDRESS(),
+          receipt.POOL(),
+        ]);
+        const underlying = new ethers.Contract(
+          underlyingAddress,
+          ERC20_ABI,
+          provider,
+        );
+        const [symbol, decimals] = await Promise.all([
+          underlying.symbol(),
+          underlying.decimals(),
+        ]);
+        const instance = new BaseAave(
+          chainName,
+          chainId,
+          [String(symbol).toLowerCase()],
+          "single",
+          {
+            symbolOfBestTokenToZapInOut: String(symbol).toLowerCase(),
+            zapInOutTokenAddress: underlyingAddress,
+            assetAddress: token.address,
+            protocolAddress: poolAddress,
+            assetDecimals: Number(decimals),
+          },
+        );
+        return {
+          uniqueId: instance.uniqueId(),
+          label: instance.toString(),
+          interface: instance,
+        };
+      } catch (error) {
+        logger.warn(
+          `EOA full exit: ${token.address} was labelled Aave but is not a discoverable V3 aToken`,
+          error,
+        );
+        return null;
+      }
+    },
+  );
+  return discovered.filter(Boolean);
+}
 
 export async function buildEoaFullExitPriceMapping({
   protocols,
@@ -100,7 +175,15 @@ export async function buildEoaFullExitPlan({
   protocols: suppliedProtocols,
   onProgress = noop,
 }) {
-  const protocols = suppliedProtocols || collectExitProtocols(chainName);
+  let protocols = suppliedProtocols || collectExitProtocols(chainName);
+  if (!suppliedProtocols) {
+    const discoveredAave = await discoverAaveWalletPositions({
+      chainName,
+      walletTokens,
+      protocols,
+    });
+    protocols = [...protocols, ...discoveredAave];
+  }
   const tokenPricesMappingTable = await buildEoaFullExitPriceMapping({
     protocols,
     walletTokens,
@@ -131,6 +214,34 @@ export async function buildEoaFullExitPlan({
         });
         return { status: "fulfilled", protocol, value };
       } catch (error) {
+        if (typeof protocol.interface.safeExitToWallet === "function") {
+          try {
+            const value = await protocol.interface.safeExitToWallet(
+              owner,
+              noop,
+              error,
+            );
+            completed += 1;
+            onProgress({
+              completed,
+              total: protocols.length,
+              stage: "positions",
+              protocol,
+              found:
+                (value?.txns || []).length > 0 ||
+                (value?.keptTokens || []).length > 0,
+              failed: false,
+              fallback: true,
+            });
+            return { status: "fulfilled", protocol, value };
+          } catch (fallbackError) {
+            error = new Error(
+              `${error?.message || error}; safe exit also failed: ${
+                fallbackError?.message || fallbackError
+              }`,
+            );
+          }
+        }
         completed += 1;
         onProgress({
           completed,
@@ -147,6 +258,8 @@ export async function buildEoaFullExitPlan({
 
   const groups = [];
   const failures = [];
+  const fallbacks = [];
+  const keptTokens = [];
   const expectedTokens = [];
   for (const result of settled) {
     if (result.status === "rejected") {
@@ -158,6 +271,15 @@ export async function buildEoaFullExitPlan({
       continue;
     }
     const txns = result.value?.txns || [];
+    if (result.value?.fallbackReason) {
+      fallbacks.push({
+        uniqueId: result.protocol.uniqueId,
+        label: result.protocol.label,
+        safeExit: Boolean(result.value.safeExit),
+        reason: result.value.fallbackReason,
+      });
+      keptTokens.push(...(result.value.keptTokens || []));
+    }
     if (!txns.length) continue;
     groups.push({
       uniqueId: result.protocol.uniqueId,
@@ -170,6 +292,8 @@ export async function buildEoaFullExitPlan({
   return {
     groups,
     failures,
+    fallbacks,
+    keptTokens: dedupeTokens(keptTokens),
     expectedTokens: dedupeTokens(expectedTokens),
     tokenPricesMappingTable,
   };

--- a/utils/retiredExitPositions.js
+++ b/utils/retiredExitPositions.js
@@ -1,0 +1,185 @@
+// Positions no vault strategy lists any more, but wallets can still hold.
+// collectExitProtocols discovers positions by walking the vault strategies, so a
+// pool commented out of — or deleted from — a strategy becomes invisible to the
+// exit pages while the funds are still staked. Equilibria pid 45 sat unreachable
+// for a wallet holding ~$3.2k of it, and pid 53 was the whole BTC Vault for seven
+// months before it was deleted outright.
+//
+// Deliberately NOT weight-0 entries in a vault strategy. Weight 0 stops zap-in
+// and hides a pool from the composition table, but every main-UI balance read
+// still walks it: BasePortfolio._getBalances, pendingRewards and
+// calProtocolAssetDustInWalletDictionary all skip the weight filter (unlike
+// _getProtocolUsdBalanceDictionary right next to it), two of them price the
+// position through the Pendle API, and they share one Promise.all whose rejection
+// wipes the whole vault page. Worse, _calculateZapOutPercentage suggests a 100%
+// zap out for any weight-0 position with a balance, which routes an expired
+// market into the Pendle SDK. A price feed that stopped answering is exactly why
+// pid 45 was commented out (3ca7d3f2, 24196bd7 — those lines are still in
+// StablecoinVault.jsx as a record). The exit path never prices anything, so
+// listing a position here rescues it without putting that feed back in front of
+// the vault page.
+//
+// Its own leaf module so utils/aaExit.js keeps knowing vault names only rather
+// than importing protocol classes, and so the next retired pool has an obvious
+// home instead of being commented out and forgotten.
+
+import { BaseEquilibria } from "../classes/Pendle/BaseEquilibria";
+import { BaseMoonwell } from "../classes/Moonwell/BaseMoonwell";
+import { BasePendlePT } from "../classes/Pendle/BasePendlePT";
+import { BaseVelodrome } from "../classes/Velodrome/BaseVelodrome";
+import { BaseVelodromeV3 } from "../classes/Velodrome/BaseVelodromeV3";
+import logger from "./logger";
+
+const AERODROME_REWARDS = [
+  {
+    symbol: "aero",
+    priceId: {
+      coinmarketcapApiId: 29270,
+    },
+    address: "0x940181a94a35a4569e4529a3cdfb74e38fd98631",
+    decimals: 18,
+  },
+];
+
+// Thunks rather than instances: one entry whose constructor throws must not take
+// the rest of the exit down with it, which needs a per-entry try/catch.
+const RETIRED_POSITION_BUILDERS = [
+  // BTC Vault's entire position (weight 1) from 2024-10-31 until 69e48b55
+  // deleted it on 2025-06-17. Staked in the Equilibria booster, so the loose
+  // ERC20 sweep cannot reach it.
+  () =>
+    new BaseEquilibria(
+      "arbitrum",
+      42161,
+      ["dwbtc", "pt dwbtc 26jun2025"],
+      "single",
+      {
+        assetAddress: "0x8cAB5Fd029ae2FBF28c53E965E4194C7260aDF0C",
+        symbolOfBestTokenToZapOut: "wbtc",
+        bestTokenAddressToZapOut: "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
+        decimalOfBestTokenToZapOut: 8,
+        pidOfEquilibria: 53,
+      },
+    ),
+  // Stable+ gold, commented out by 24196bd7 on 2025-11-05. Verified on-chain:
+  // EqbZap withdraw(45, amount) approving poolInfo(45).token
+  // (0xcf12c0268bd3038d7d811d72eb511cf3b050922c) is the same call Debank
+  // proposes for this position.
+  () =>
+    new BaseEquilibria(
+      "arbitrum",
+      42161,
+      ["usdc", "pt gusdc 26dec2024"],
+      "single",
+      {
+        assetAddress: "0xa877a0E177b54A37066c1786F91a1DAb68F094AF",
+        symbolOfBestTokenToZapOut: "gusdc",
+        bestTokenAddressToZapOut: "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+        decimalOfBestTokenToZapOut: 6,
+        pidOfEquilibria: 45,
+      },
+    ),
+  // ETH Vault long_term_bond at weight 0.3 until 51a0212b removed it on
+  // 2025-09-15. An ERC721, and BaseVelodromeV3._getAllNftIDs filters by
+  // token0/token1/tick range — so the wsteth-mseth position still in EthVault
+  // shares this NFT manager without ever finding these tokens.
+  () =>
+    new BaseVelodromeV3("base", 8453, ["wsteth", "wrseth"], "LP", {
+      protocolName: "aerodrome",
+      protocolVersion: "v3",
+      assetDecimals: 18,
+      assetAddress: "0x827922686190790b37229fd06084350E74485b72",
+      poolAddress: "0x14dcCDd311Ab827c42CCA448ba87B1ac1039e2A4",
+      guageAddress: "0x4197186D3D65f694018Ae4B80355225Ce1dD64AD",
+      lpTokens: [
+        ["wsteth", "0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452", 18],
+        ["wrseth", "0xEDfa23602D0EC14714057867A78d01e94176BEA0", 18],
+      ],
+      tickers: {
+        tickLower: 1411,
+        tickUpper: 1415,
+        tickSpacing: 1,
+      },
+      rewards: [],
+    }),
+  // The three below hold their position as a plain ERC20 receipt token, which
+  // the wallet sweep already transfers. Listed anyway because the sweep depends
+  // on Debank listing the token, and a position with no balance produces no row
+  // at all — so the only cost of being wrong here is a few extra reads.
+
+  // Index 500 Vault btc at weight 1 until 78496126 commented it out and
+  // 69e48b55 deleted it, both on 2025-06-17. Still commented out in
+  // BtcVault.jsx:26-43.
+  () =>
+    new BasePendlePT("base", 8453, ["pt mcbbtc 26jun2025"], "single", {
+      marketAddress: "0xd94Fd7bcEb29159405Ae1E06Ce80e51EF1A484B0",
+      assetAddress: "0x5C6593F57EE95519fF6a8Cd16A5e41Ff50af239a",
+      assetDecimals: 8,
+      symbolOfBestTokenToZapOut: "cbbtc",
+      bestTokenAddressToZapOut: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
+      decimalOfBestTokenToZapOut: 8,
+    }),
+  // ETH Vault long_term_bond at weight 0.4 for three months until 10765e84
+  // removed it on 2025-04-14.
+  () =>
+    new BaseMoonwell("base", 8453, ["wsteth"], "single", {
+      symbolOfBestTokenToZapInOut: "wsteth",
+      zapInOutTokenAddress: "0xc1cba3fcea344f92d9239c08c0568f6f2f0ee452",
+      decimalsOfZapInOutToken: 18,
+      assetAddress: "0x627Fe393Bc6EdDA28e99AE648fD6fF362514304b",
+      protocolAddress: "0x627Fe393Bc6EdDA28e99AE648fD6fF362514304b",
+      assetDecimals: 8,
+    }),
+  // Stable+ gold at weight 0.03 for two days: added by 805bb555 on 2024-12-13,
+  // removed by 274ed6c9 on 2024-12-15. Built as BaseAerodrome back then, a class
+  // deleted in a23c6060 — BaseVelodrome with protocolName "aerodrome" reaches
+  // the same pool and gauge, so only the uniqueId's class segment differs from
+  // what a 2024 wallet would have entered.
+  () =>
+    new BaseVelodrome("base", 8453, ["usdc", "zunusd"], "LP", {
+      protocolName: "aerodrome",
+      protocolVersion: "0",
+      routerAddress: "0xcF77a3Ba9A5CA399B7c97c74d54e5b1Beb874E43",
+      assetAddress: "0x72c3eEd99b100526e1a25e04Ce7A22D7C3005c06",
+      assetDecimals: 18,
+      guageAddress: "0x55f9db31250D311c54D61F1384F75dbdF54b8305",
+      lpTokens: [
+        ["usdc", "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", 6],
+        ["zunusd", "0xD5B9dDB04f20eA773C9b56607250149B26049B1F", 18],
+      ],
+      rewards: AERODROME_REWARDS,
+    }),
+];
+
+// Exported so a test can prove no entry is stranded on a chain the exit pages
+// never scan: an entry keyed to an unsupported chain would silently never be
+// returned, reading as rescued while staying unreachable.
+export const RETIRED_POSITION_COUNT = RETIRED_POSITION_BUILDERS.length;
+
+/**
+ * Retired protocol instances on `chainName`.
+ * Bare instances, not exit entries: collectExitProtocols owns the
+ * uniqueId/label/dedupe shaping, so a retired position can never present itself
+ * differently from a vault-derived one.
+ * The chain is read off the instance rather than stored beside it — the vault
+ * strategies key a chain and construct its protocols with the same string, and a
+ * second copy here could drift from the one the exit actually reads.
+ */
+export function retiredExitPositions(chainName) {
+  const positions = [];
+  for (const build of RETIRED_POSITION_BUILDERS) {
+    let instance;
+    try {
+      instance = build();
+    } catch (error) {
+      logger.warn(
+        "AA Exit: could not build a retired position, skipping it",
+        error,
+      );
+      continue;
+    }
+    if (instance.chain.toLowerCase() !== chainName) continue;
+    positions.push(instance);
+  }
+  return positions;
+}

--- a/utils/retiredExitPositions.js
+++ b/utils/retiredExitPositions.js
@@ -24,6 +24,7 @@
 // home instead of being commented out and forgotten.
 
 import { BaseEquilibria } from "../classes/Pendle/BaseEquilibria";
+import { BaseAave } from "../classes/Aave/BaseAave";
 import { BaseMoonwell } from "../classes/Moonwell/BaseMoonwell";
 import { BasePendlePT } from "../classes/Pendle/BasePendlePT";
 import { BaseVelodrome } from "../classes/Velodrome/BaseVelodrome";
@@ -44,6 +45,38 @@ const AERODROME_REWARDS = [
 // Thunks rather than instances: one entry whose constructor throws must not take
 // the rest of the exit down with it, which needs a per-entry try/catch.
 const RETIRED_POSITION_BUILDERS = [
+  // Aave V3 Arbitrum positions are not part of any production vault strategy.
+  // Keep the common native-USDC and WETH aTokens in the exit registry; raw
+  // wallet discovery in eoaFullExit additionally handles any other V3 aToken.
+  () =>
+    new BaseAave("arbitrum", 42161, ["usdc"], "single", {
+      symbolOfBestTokenToZapInOut: "usdc",
+      zapInOutTokenAddress: "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+      assetAddress: "0x724dc807b04555b71ed48a6896b6F41593b8C637",
+      protocolAddress: "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
+      assetDecimals: 6,
+    }),
+  () =>
+    new BaseAave("arbitrum", 42161, ["weth"], "single", {
+      symbolOfBestTokenToZapInOut: "weth",
+      zapInOutTokenAddress: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      assetAddress: "0xe50fA9b3c56FfB159cB0FCA61F5c9D750e8128c8",
+      protocolAddress: "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
+      assetDecimals: 18,
+    }),
+  // Direct PT held in a wallet, distinct from the pid 45 Equilibria market LP.
+  // If Pendle no longer builds a redemption route, BaseProtocol's safe fallback
+  // leaves this PT untouched and reports it for manual handling.
+  () =>
+    new BasePendlePT("arbitrum", 42161, ["pt gusdc 26dec2024"], "single", {
+      marketAddress: "0xa877a0E177b54A37066c1786F91a1DAb68F094AF",
+      assetAddress: "0x2be6fab4d1408e7ad6ad91ce7b77fa2a7670782f",
+      ytAddress: "0x03577ffa91edb93ac3aee081efbe6f323da949e1",
+      assetDecimals: 6,
+      symbolOfBestTokenToZapOut: "usdc",
+      bestTokenAddressToZapOut: "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+      decimalOfBestTokenToZapOut: 6,
+    }),
   // BTC Vault's entire position (weight 1) from 2024-10-31 until 69e48b55
   // deleted it on 2025-06-17. Staked in the Equilibria booster, so the loose
   // ERC20 sweep cannot reach it.


### PR DESCRIPTION
## Summary

- Add `safeExitToWallet` fallback in BaseProtocol for unstake-only exits when downstream redemption/liquidity routes fail.
- Filter never-swap tokens (USDX) from DustZap conversions via address-level `NEVER_SWAP_TOKENS` denylist.
- Discover Aave V3 aTokens from raw wallet tokens for EOA full exit, so deleted vault configs cannot make a position unreachable.
- Lock retired Aave/Equilibria/Aura/Convex positions into the exit registry.

## Test plan
- `yarn test` for dustConversion, emergencyExit, aaExit, eoaFullExit suites.