### PR TITLE
fix: transfer loose Equilibria LP when historical staking read fails

### DIFF
--- a/__tests__/intent/emergencyExit.test.js
+++ b/__tests__/intent/emergencyExit.test.js
@@ -266,6 +266,54 @@ describe("emergencyTransfer", () => {
     expect(data).includes(word("500"));
   });
 
+  it.each([
+    [44, "0x279b44E48226d40Ec389129061cb0B56C5c09e46"],
+    [45, "0xa877a0E177b54A37066c1786F91a1DAb68F094AF"],
+    [47, "0xcB471665BF23B2Ac6196D84D947490fd5571215f"],
+  ])(
+    "transfers loose Equilibria pid %s LP when the historical staking read fails",
+    async (pid, marketAddress) => {
+      const protocol = collectExitProtocols("arbitrum").find(
+        (entry) => entry.interface.pidOfEquilibria === pid,
+      ).interface;
+      vi.spyOn(protocol, "assetBalanceOf").mockResolvedValue(
+        ethers.BigNumber.from("500"),
+      );
+      vi.spyOn(protocol, "stakeBalanceOf").mockRejectedValue(
+        new Error("historical reward pool unavailable"),
+      );
+
+      const { txns, rewardBalances } = await protocol.emergencyTransfer(
+        OWNER,
+        RECIPIENT,
+        noop,
+      );
+
+      expect(txns).toHaveLength(1);
+      expect(txns[0].to.toLowerCase()).toBe(marketAddress.toLowerCase());
+      const data = await encode(txns[0]);
+      expect(data).includes(TRANSFER_SELECTOR);
+      expect(data).includes(word("500"));
+      expect(rewardBalances).toEqual([]);
+    },
+  );
+
+  it("still reports an Equilibria staking read failure when no loose LP can be confirmed", async () => {
+    const protocol = collectExitProtocols("arbitrum").find(
+      (entry) => entry.interface.pidOfEquilibria === 45,
+    ).interface;
+    vi.spyOn(protocol, "assetBalanceOf").mockResolvedValue(
+      ethers.constants.Zero,
+    );
+    vi.spyOn(protocol, "stakeBalanceOf").mockRejectedValue(
+      new Error("historical reward pool unavailable"),
+    );
+
+    await expect(
+      protocol.emergencyTransfer(OWNER, RECIPIENT, noop),
+    ).rejects.toThrow("historical reward pool unavailable");
+  });
+
   it("does not emit withdraw(0) when EOA full exit only finds wallet LP", async () => {
     const [protocol] = protocolsOn(
       getPortfolioHelper("Velodrome Vault"),

--- a/classes/Pendle/BaseEquilibria.js
+++ b/classes/Pendle/BaseEquilibria.js
@@ -14,6 +14,7 @@ import THIRDWEB_CLIENT from "../../utils/thirdweb.js";
 import { approve, CHAIN_ID_TO_CHAIN } from "../../utils/general.js";
 import BaseProtocol from "../BaseProtocol.js";
 import ERC20_ABI from "../../lib/contracts/ERC20.json" assert { type: "json" };
+import logger from "../../utils/logger";
 
 axiosRetry(axios, { retryDelay: axiosRetry.exponentialDelay });
 export class BaseEquilibria extends BaseProtocol {
@@ -385,6 +386,48 @@ export class BaseEquilibria extends BaseProtocol {
   async lockUpPeriod() {
     return 0;
   }
+
+  // A retired Equilibria pool can stop answering its booster/reward-pool reads
+  // even though the Pendle Market LP is already loose in the wallet. The base
+  // emergency path asks for the staked balance before it reads that loose LP,
+  // so such a stale PID would otherwise hide a perfectly transferable ERC20.
+  // Read both paths independently: prefer the complete unstake + transfer when
+  // it builds, but fall back to handing over the loose LP when only the staking
+  // side is unreadable.
+  async emergencyTransfer(owner, recipient, updateProgress, options = {}) {
+    if (options.skipWalletBalance) {
+      return super.emergencyTransfer(owner, recipient, updateProgress, options);
+    }
+
+    const [walletBalanceResult, completeExitResult] = await Promise.allSettled([
+      this.assetBalanceOf(owner),
+      super.emergencyTransfer(owner, recipient, updateProgress, options),
+    ]);
+
+    if (completeExitResult.status === "fulfilled") {
+      return completeExitResult.value;
+    }
+
+    const walletBalance =
+      walletBalanceResult.status === "fulfilled"
+        ? ethers.BigNumber.from(walletBalanceResult.value || 0)
+        : ethers.constants.Zero;
+    if (walletBalance.isZero()) {
+      throw completeExitResult.reason;
+    }
+
+    logger.warn(
+      `Equilibria emergency exit: could not read staked pid ${this.pidOfEquilibria}; transferring the loose market LP only`,
+      completeExitResult.reason,
+    );
+    const transferTxn = prepareContractCall({
+      contract: this.assetContract,
+      method: "transfer",
+      params: [recipient, walletBalance],
+    });
+    return { txns: [transferTxn], rewardBalances: [] };
+  }
+
   async _stake(amount, updateProgress) {
     const approveTxn = approve(
       this.assetContract.address,


### PR DESCRIPTION
Merge main into prod. Fixes Equilibria emergency exit so it still transfers loose market LP when the historical staking read (booster/reward-pool) fails for a retired PID.